### PR TITLE
Update mvm_rottenburg_rev_int_spanner_switchup.pop

### DIFF
--- a/scripts/population/mvm_rottenburg_rev_int_spanner_switchup.pop
+++ b/scripts/population/mvm_rottenburg_rev_int_spanner_switchup.pop
@@ -2480,6 +2480,7 @@ WaveSchedule
 			TotalCurrency 250
 			WaitBeforeStarting 10
 			FirstSpawnWarningSound mvm/mvm_tele_deliver.wav
+			FirstSpawnMessage "{red}Tank deployed with 15k (15000) HP!" [$SIGSEGV] //Chat message when a bot is spawned for the first time
 
 			Tank
 			{


### PR DESCRIPTION
added spawn text for the one mainwave tank to tell the players the HP of the tank.