### PR TITLE
Update mvm_traumatic_b2a_int_bloodwater.pop

### DIFF
--- a/scripts/population/mvm_traumatic_b2a_int_bloodwater.pop
+++ b/scripts/population/mvm_traumatic_b2a_int_bloodwater.pop
@@ -2,7 +2,7 @@
 #base robot_standard.pop
 #base robot_giant.pop
 
-we_do_a_little_trollllllllllllling
+population
 {
 	CanBotsAttackWhileInSpawnRoom no
 	RespawnWaveTime	2
@@ -10,11 +10,11 @@ we_do_a_little_trollllllllllllling
 	EventPopFile Halloween
 	ZombiesNoWave666 1 [$SIGSEGV] // If set to 1, the game will not display wave 666 when EventPopFile is set (default: 0)
 	ForceHoliday 2 [$SIGSEGV]
-	NoRomevisionCosmetics 1 [$SIGSEGV] //Delete if ape
+	NoRomevisionCosmetics 1 [$SIGSEGV]
 	SendBotsToSpectatorImmediately 1 [$SIGSEGV]
 	NoCritPumpkin 1 [$SIGSEGV]
 	ImprovedAirblast 0 [$SIGSEGV] //APEEEEEEEEEEEEEEEEEEEE
-	TextPrintTime 0 [$SIGSEGV] //rafradek you retard why is this on by default who even watned this
+	TextPrintTime 0 [$SIGSEGV] 
 	PrecacheModel "models/bots/boss_bot/boss_tank_color.mdl" [$SIGSEGV] //PRECACHE THESE
 	BotsDropSpells 1 [$SIGSEGV]
 	GiantsDropRareSpells 1 [$SIGSEGV]
@@ -55,7 +55,6 @@ we_do_a_little_trollllllllllllling
 		//fuck minify
 		"Fireball" 3
 		"Fireball" 3
-		"Minify" 1
 		//small chance for rare
 	    "Tesla Bolt" 1
 		"Meteor Shower" 1
@@ -75,7 +74,7 @@ we_do_a_little_trollllllllllllling
 	
 	PointTemplates [$SIGSEGV]
 	{
-		ColorTank_Prpl //hellmet is ape
+		ColorTank_Prpl 
         {
             OnSpawnOutput
             {
@@ -172,7 +171,7 @@ we_do_a_little_trollllllllllllling
 			}
 		}
 
-		T_TFBot_Medic_Kritz //HEY GUYS, KILL THE MEDIC FIRST //not bigheal fuck you
+		T_TFBot_Medic_Kritz //HEY GUYS, KILL THE MEDIC FIRST //not bigheal 
 		{
 		    Class Medic
 			ClassIcon medic_kritz ///custom icon
@@ -495,7 +494,7 @@ we_do_a_little_trollllllllllllling
 			{
 				TFBot
 				{
-					//Template T_TFBot_HeavyWeapons_ShotGun //no fuck you
+					//Template T_TFBot_HeavyWeapons_ShotGun //no
 					Class Heavyweapons
 					ClassIcon heavy_shotgun
 					Name "Heavy Shotgun"
@@ -648,7 +647,7 @@ we_do_a_little_trollllllllllllling
 			WaitBeforeStarting 5
 			TotalCurrency 300
 			FirstSpawnWarningSound "mvm/mvm_tank_start.wav"
-			FirstSpawnMessage "{blue}Tank spawned in with 15k (15000) HP!" [$SIGSEGV] //Chat message when a bot is spawned for the first time
+			FirstSpawnMessage "{blue}Tank deployed with 15k (15000) HP!" [$SIGSEGV] //Chat message when a bot is spawned for the first time
 			
 			Tank
 			{
@@ -995,7 +994,7 @@ we_do_a_little_trollllllllllllling
 
 		WaveSpawn
 		{
-			Name fuckyoubazooksijustwantedafuckingsinglesubwave
+			Name stage2
 			WaitForAllSpawned giantslol
 			Where spawnbot
 			TotalCount 4
@@ -1043,7 +1042,7 @@ we_do_a_little_trollllllllllllling
 			WaitBeforeStarting 50
 			TotalCurrency 200
 			FirstSpawnWarningSound "mvm/mvm_tank_start.wav"
-			FirstSpawnMessage "{blue}Tank spawned in with 20k (20000) HP!" [$SIGSEGV] //Chat message when a bot is spawned for the first time
+			FirstSpawnMessage "{blue}Tank deployed with 20k (20000) HP!" [$SIGSEGV] //Chat message when a bot is spawned for the first time
 			
 			
 			Tank
@@ -1113,7 +1112,7 @@ we_do_a_little_trollllllllllllling
 			SpawnCount 1
 			TotalCurrency 200
 			FirstSpawnWarningSound "mvm/mvm_tank_start.wav"
-			FirstSpawnMessage "{blue}Tank spawned in with 20k (20000) HP!" [$SIGSEGV] //Chat message when a bot is spawned for the first time
+			FirstSpawnMessage "{blue}Tank deployed with 20k (20000) HP!" [$SIGSEGV] //Chat message when a bot is spawned for the first time
 			
 			
 			Tank
@@ -1234,7 +1233,7 @@ we_do_a_little_trollllllllllllling
 			TotalCurrency 200
 			WaitBeforeStarting 40
 			FirstSpawnWarningSound "mvm/mvm_tank_start.wav"
-			FirstSpawnMessage "{blue}Tank spawned in with 22k (22000) HP!" [$SIGSEGV] //Chat message when a bot is spawned for the first time
+			FirstSpawnMessage "{blue}Tank deployed with 22k (22000) HP!" [$SIGSEGV] //Chat message when a bot is spawned for the first time
 			
 			
 			Tank


### PR DESCRIPTION
changed tank/blimp spawn text.
removed needless comments.
fixed spell bug where minify can still be rolled from spells.