### PR TITLE
Buffed mvm_deathpour_rc1_exp_blackout.pop

### DIFF
--- a/scripts/population/mvm_deathpour_rc1_exp_blackout.pop
+++ b/scripts/population/mvm_deathpour_rc1_exp_blackout.pop
@@ -81,6 +81,35 @@
 //removed alwayscrit from medics
 //toned down w3 engies
 
+//2023:
+//buff 1.
+//reduce starting to 1200
+//w1:
+//double blimp hp, make it spawn at start.
+//w2:
+//make pistol gscouts into scatters.
+//make tank waitforallspawned and +5k hp
+//w3:
+//add blimp at the start.
+//w4:
+//make gunspies crit enforcer (armor pierce gun)
+//make xbowmeds into crit df pyros
+//make tank waitforallspawned and reduce wait by 10s, buff hp by 5k
+//w5:
+//fixed giant explanation colour
+//add lower maxactive shortstop scouts which begin after mainwave is all spawned.
+
+//buff 2.
+//w1:
+//moved giant shottys to the unused cave spawn.
+//moved soldiers to spawnbot invasion.
+//w2:
+//gave the giant scouts randomchoice scatters like in w1.
+//w3:
+//made engies build teleporters.
+//w5:
+//regen gmeds into popping gmeds.
+
 #base robot_standard.pop
 #base robot_giant.pop
 
@@ -88,7 +117,7 @@ WaveSchedule
 {
 	CanBotsAttackWhileInSpawnRoom no
 	RespawnWaveTime	2
-	StartingCurrency 1600 //1200 //1600 yoovy you fucking ape
+	StartingCurrency 1200 //1600 //1200 //1600 
 	Advanced 1
 	EventPopFile Halloween
 	ZombiesNoWave666 1 [$SIGSEGV] // If set to 1, the game will not display wave 666 when EventPopFile is set (default: 0)
@@ -96,7 +125,7 @@ WaveSchedule
 	SendBotsToSpectatorImmediately 1 [$SIGSEGV]
 	MedigunShieldDamage 1 [$SIGSEGV] //Shield Medics can now harm human team
 	NoCritPumpkin 1 [$SIGSEGV]
-	ImprovedAirblast 0 [$SIGSEGV] //APEEEEEEEEEEEEEEEEEEEE
+	ImprovedAirblast 0 [$SIGSEGV]
 	TextPrintTime 0 [$SIGSEGV]
 	PrecacheModel "models/bots/boss_bot/boss_blimp.mdl" [$SIGSEGV]
 	PrecacheModel "models/bots/boss_bot/boss_blimp_damage1.mdl" [$SIGSEGV]
@@ -687,34 +716,6 @@ WaveSchedule
 			WeaponRestrictions PrimaryOnly
 		}
 
-		T_TFBot_Spy_Revolver
-		{
-			Class Spy
-			ClassIcon spy_revolver_lite
-			Skill Normal
-			Name "Gun Spy"
-			WeaponRestrictions PrimaryOnly
-			Item "The Au Courant Assassin"
-			Item "Spy Noble Hair"
-		}
-
-		T_TFBot_Scout_Milk
-		{
-			Class Scout
-			Name "Milkman Scout"
-			Skill Expert
-			ClassIcon scout_milk
-			Item "Mad Milk"
-			Item "The Milkman"
-			WeaponRestrictions SecondaryOnly
-			Attributes AlwaysFireWeapon
-			ItemAttributes 
-			{
-				ItemName "Mad Milk"
-				"effect bar recharge rate increased" 0.01
-			}
-		}
-
 		T_TFBot_Giant_Medic_Shield_Nopop
 		{
 			Class Medic
@@ -748,15 +749,6 @@ WaveSchedule
 			}
 		}
 
-		T_TFBot_Engineer_Shotgun
-		{
-			Class Engineer
-			Name "Shotgun Engineer"
-			ClassIcon heavy_shotgun
-			Skill Easy
-			BehaviorModifiers Push
-		}
-
 		T_TFBot_Pyro_DF
 		{
 			Class Pyro
@@ -774,32 +766,6 @@ WaveSchedule
 			Skill Easy
 			Item "The Shortstop"
 			Item "The Milkman"
-		}
-
-		T_TFBot_Giant_Soldier_Spammer_HealOnKill
-		{
-			Class Soldier
-			Name "Giant HOK Rapid Fire Soldier"
-			ClassIcon soldier_spammer_regen
-			Health 4200
-			Skill Expert
-			Attributes MiniBoss Tag bot_giant 
-			//Attributes UseBossHealthBar
-			ItemAttributes
-			{
-				ItemName "TF_WEAPON_ROCKETLAUNCHER"
-				"faster reload rate" -0.8
-				"fire rate bonus" 0.5
-				"heal on kill" 4200
-				"Projectile speed increased" 0.65
-			}
-			CharacterAttributes
-			{
-				"move speed bonus"	0.5
-				"damage force reduction" 0.5
-				"airblast vulnerability multiplier"	0.5
-				"override footstep sound set" 3
-			}
 		}
 
 		T_TFBot_Giant_Soldier_Spammer_Buff
@@ -887,43 +853,6 @@ WaveSchedule
 				"increase buff duration"	9.0
 				"deploy time increased" 0.5
 			}
-		}
-		
-		Boss
-		{
-			Class Heavyweapons
-			Name "Chief Heal Deflector Heavy"
-			ClassIcon heavy_deflector_healonkill_normal
-			Skill Expert
-			Health 45000
-			WeaponRestrictions PrimaryOnly
-			Attributes UseBossHealthBar
-			Attributes MiniBoss Tag bot_giant
-			Attributes AlwaysCrit
-			Tag bot_giant
-			Item "Deflector"
-			Item "The Tungsten Toque"
-			ItemAttributes
-			{
-				ItemName "Deflector"
-				"damage bonus"	1.5
-				"attack projectiles" 2
-				"heal on kill" 5000
-				"heal on hit for rapidfire" 10
-			}
-			CharacterAttributes
-			{
-				"move speed bonus"	0.35
-				"damage force reduction" 0.0
-				"airblast vulnerability multiplier" 0.0
-				"airblast vertical vulnerability multiplier" 0.0
-				"override footstep sound set" 2
-				"health regen" 50
-				//"jarate backstabber" 1 
-				//"backstab shield" 1 //peak 2020 randomguy right here
-				"rage giving scale" 0.1
-			}
-			UseMeleeThreatPrioritization 1 [$SIGSEGV] //Prefer players close to the bot
 		}
 	}
 	
@@ -1096,16 +1025,16 @@ WaveSchedule
 		WaveSpawn [$SIGSEGV]
 		{
 			Name stage2
-			WaitForAllDead stage1
+			//WaitForAllDead stage1
 			TotalCount 1
 			SpawnCount 1
 			WaitBeforeStarting 10
 			TotalCurrency 100
-			FirstSpawnMessage "{blue}Blimp deployed with 7.5k (7500) HP!" [$SIGSEGV] //Chat message when a bot is spawned for the first time
+			FirstSpawnMessage "{blue}Blimp deployed with 15k (15000) HP!" [$SIGSEGV] //Chat message when a bot is spawned for the first time
 			
 			Tank // mvm blimp concept designed by hell-met
 			{
-				Health 7500 //10000 //15000 //12500
+				Health 15000 //10000 //15000 //12500
 				Speed 150 //225
 				DisableSmokestack 1 [$SIGSEGV]
 				Classicon blimp2_lite [$SIGSEGV]
@@ -1177,7 +1106,7 @@ WaveSchedule
 		{
 			Name stage3
 			WaitForAllDead stage2
-			Where spawnbot
+			Where spawnbot_left
 			TotalCount 3
 			MaxActive 3
 			SpawnCount 1
@@ -1189,7 +1118,7 @@ WaveSchedule
 			
 				TFBot
 				{
-					Template T_TFBot_Giant_HeavyWeapons_ShotGun
+					Template T_TFBot_Giant_HeavyWeapons_Shotgun
 				}
 		}
 		
@@ -1197,7 +1126,7 @@ WaveSchedule
 		{
 			Name stage3
 			WaitForAllDead stage2
-			Where spawnbot_left
+			Where spawnbot_invasion
 			TotalCount 40
 			MaxActive 12
 			SpawnCount 4
@@ -1379,12 +1308,28 @@ WaveSchedule
 			TotalCurrency 100
 			RandomSpawn 1
 			
-			
+			RandomChoice
+			{
 				TFBot
 				{
-					Template T_TFBot_Giant_Scout_Pistol
+					Template T_TFBot_Giant_Scout
+					Item "The Soda Popper"
 					Attributes AlwaysCrit
 				}
+
+				TFBot
+				{
+					Template T_TFBot_Giant_Scout
+					Item "The Force-a-Nature"
+					Attributes AlwaysCrit
+				}
+
+				TFBot
+				{
+					Template T_TFBot_Giant_Scout
+					Attributes AlwaysCrit
+				}
+			}
 		}
 		
 		WaveSpawn
@@ -1411,20 +1356,19 @@ WaveSchedule
 		WaveSpawn
 		{
 			Name stage3
-			WaitForAllDead stage2
+			WaitForAllSpawned stage2
 			Where spawnbot
 			TotalCount 1
 			MaxActive 1
 			SpawnCount 1
-			WaitBeforeStarting 5
-			WaitBetweenSpawns 7
+			WaitBeforeStarting 0
 			TotalCurrency 150
 			RandomSpawn 1
-			FirstSpawnMessage "{blue}Tank deployed with 30k (30000) HP!" [$SIGSEGV] //Chat message when a bot is spawned for the first time
+			FirstSpawnMessage "{blue}Tank deployed with 35k (35000) HP!" [$SIGSEGV] //Chat message when a bot is spawned for the first time
 			
 			Tank
 			{
-				Health 30000
+				Health 35000
 				Speed 75
 				Name "tankboss"
 				Skin 0									// 0 - normal skin, 1 - final wave skin
@@ -1530,9 +1474,54 @@ WaveSchedule
 				//} 
 		//}
 
+		WaveSpawn [$SIGSEGV]
+		{
+			Name stage2
+			//WaitForAllDead stage1
+			TotalCount 1
+			SpawnCount 1
+			WaitBeforeStarting 10
+			TotalCurrency 100
+			FirstSpawnMessage "{blue}Blimp deployed with 20k (20000) HP!" [$SIGSEGV] //Chat message when a bot is spawned for the first time
+			
+			Tank // mvm blimp concept designed by hell-met
+			{
+				Health 20000 //10000 //15000 //12500
+				Speed 150 //225
+				DisableSmokestack 1 [$SIGSEGV]
+				Classicon blimp2_lite [$SIGSEGV]
+				Skin 1 
+				MaxTurnRate 75 [$SIGSEGV]
+				Model "models/bots/boss_bot/boss_blimp.mdl" [$SIGSEGV]
+				Gravity 0 [$SIGSEGV]
+				DisableTracks 1 [$SIGSEGV]
+				DisableChildModels 1 [$SIGSEGV]
+				ReplaceModelCollisions 1 [$SIGSEGV]
+				EngineLoopSound "npc\combine_gunship\dropship_engine_distant_loop1.wav" [$SIGSEGV]
+				PingSound "npc\combine_gunship\ping_search.wav" [$SIGSEGV]
+				Name "tankboss"
+				StartingPathTrackNode "downpour_blimp_path_1"
+				OnKilledOutput
+				{
+					Target boss_dead_relay
+					Action Trigger
+				}
+				OnBombDroppedOutput
+				{
+					Target boss_deploy_relay
+					Action Trigger
+				}
+			}
+			StartWaveOutput //display the blimp arrow
+			{
+				Target blimp_hint
+				Action Show
+			}
+		}
+		
 		WaveSpawn
 		{
-			Name pyro_nospyallowed //ape
+			Name pyro_nospyallowed 
 			//WaitForAllDead stage1
 			Where spawnbot_right
 			TotalCount 50
@@ -1562,7 +1551,7 @@ WaveSchedule
 			SpawnCount 3
 			WaitBeforeStarting 1 //0
 			WaitBetweenSpawns 4.5
-			TotalCurrency 100
+			TotalCurrency 80
 			RandomSpawn 1
 			
 
@@ -1618,7 +1607,7 @@ WaveSchedule
 			SpawnCount 2
 			WaitBeforeStarting 25
 			WaitBetweenSpawns 20 //10
-			TotalCurrency 150
+			TotalCurrency 100
 			RandomSpawn 1
 			Support Limited
 			
@@ -1627,7 +1616,8 @@ WaveSchedule
 			{
 				TFBot
 				{
-					Template T_TFBot_Engineer_Sentry_Battle
+					Template T_TFBot_Engineer_Sentry_Tele_Battle
+					TeleportWhere spawnbot_right
 					//Attributes AlwaysCrit
 					Attributes IgnoreFlag
 				} 
@@ -1650,7 +1640,7 @@ WaveSchedule
 			SpawnCount 1
 			WaitBeforeStarting 0
 			WaitBetweenSpawns 15 //20
-			TotalCurrency 150
+			TotalCurrency 120
 			RandomSpawn 1
 			
 			
@@ -1741,36 +1731,24 @@ WaveSchedule
 			Formationsize 100
 				TFBot
 				{
-					Template T_TFBot_Medic_Crossbow
+					Template T_TFBot_Pyro_DF
 					Attributes AlwaysCrit
 					Skill Expert
-					Action FetchFlag [$SIGSEGV]
-					ItemAttributes
-					{
-						ItemName "The Crusader's Crossbow"
-						"damage bonus" 1.5 //2
-					}
 				}
 				
 				TFBot
 				{
 					Class Spy
+					Name "Enforcer Spy"
+					ClassIcon spy_enforcer_nys
 					Skill Expert
-					Name "Revolver Spy"
-					Item "The Stealth Steeler"
-					ClassIcon spy_revolver_lite
-					Action FetchFlag [$SIGSEGV]
 					Attributes AlwaysCrit
-					WeaponRestrictions PrimaryOnly
+					Item "The Enforcer"
+					Item "The Stealth Steeler"
 					CharacterAttributes
 					{
 						"cannot disguise" 1
 					}
-					//ItemAttributes
-					//{
-						//ItemName "TF_WEAPON_REVOLVER"
-						//"damage bonus" 2 //haha they have no idea
-					//}
 				}
 			}
 		}
@@ -1856,21 +1834,21 @@ WaveSchedule
 		WaveSpawn
 		{
 			Name stage2
-			WaitForAllDead stage1
+			WaitForAllSpawned stage1
 			Where spawnbot
 			TotalCount 1
 			MaxActive 1
 			SpawnCount 1
-			WaitBeforeStarting 30 //0
+			WaitBeforeStarting 20 //30 //0
 			WaitBetweenSpawns 20
 			TotalCurrency 50
 			RandomSpawn 1
-			FirstSpawnMessage "{blue}Tank spawned in with 35k (35000) HP!" [$SIGSEGV] //Chat message when a bot is spawned for the first time																														
+			FirstSpawnMessage "{blue}Tank deployed with 40k (40000) HP!" [$SIGSEGV] //Chat message when a bot is spawned for the first time																														
 			
 			
 			Tank
 			{
-				Health 35000 //30000 //35000
+				Health 40000 //35000 //30000 //35000
 				Speed 75
 				Name "tankboss"
 				Skin 1									// 0 - normal skin, 1 - final wave skin
@@ -1903,7 +1881,7 @@ WaveSchedule
 
 		Explanation [$SIGSEGV]  //Dispayed once the wave is initialized
 		{
-			Line "{red}There are support giants coming this wave!{reset}"
+			Line "{blue}There are support giants coming this wave!{reset}"
 		}
 
 		WaveSpawn
@@ -2044,7 +2022,7 @@ WaveSchedule
 				
 				TFBot
 				{
-					Template T_TFBot_Giant_Medic_Regen
+					Template T_TFBot_Giant_Medic //_Regen
 				}
 			}
 		}
@@ -2101,7 +2079,7 @@ WaveSchedule
 		
 		WaveSpawn
 		{
-			Name stage3
+			Name stage3a
 			WaitForAllDead stage2
 			Where spawnbot
 			TotalCount 48
@@ -2118,6 +2096,27 @@ WaveSchedule
 					Template T_TFBot_Scout_Shortstop
 					//Attributes AlwaysCrit
 					//ClassIcon scout_shortstop_giant
+				}
+		}
+
+		WaveSpawn
+		{
+			Name stage3
+			WaitForAllSpawned stage3a
+			Where spawnbot
+			TotalCount 48
+			MaxActive 12
+			SpawnCount 3
+			WaitBeforeStarting 8
+			WaitBetweenSpawns 4
+			TotalCurrency 100
+			RandomSpawn 1
+			Support 1
+			
+			
+				TFBot
+				{
+					Template T_TFBot_Scout_Shortstop
 				}
 		}
 		


### PR DESCRIPTION
reduced starting to $1200
w1:
doubled blimp hp, make it spawn at start.
moved giant shottys to the unused cave spawn.
moved soldiers to spawnbot invasion.
w2:
made pistol gscouts into scatters.
gave the giant scouts randomchoice scatters like in w1. make tank waitforallspawned and +5k hp
w3:
added blimp at the start.
made engies build teleporters.
w4:
made gunspies crit enforcer (armor pierce gun)
made xbowmeds into crit df pyros
made tank waitforallspawned and reduce wait by 10s, buff hp by 5k 
w5:
fixed giant explanation colour
added lower maxactive shortstop scouts support which begin after mainwave is all spawned. regen gmeds into popping gmeds.

(this was tested but feel free to if you want to)