### PR TITLE
Fix mvm_rottenburg_rev_int_spanner_switchup.pop

### DIFF
--- a/scripts/population/mvm_rottenburg_rev_int_spanner_switchup.pop
+++ b/scripts/population/mvm_rottenburg_rev_int_spanner_switchup.pop
@@ -2485,7 +2485,7 @@ WaveSchedule
 
 			Tank
 			{
-				Health 15000
+				Health 20000 //15000
 				Name tankbossred
 				ClassIcon tank_red	// _lite
 				Model models/bots/boss_bot/boss_tankred.mdl
@@ -2852,8 +2852,6 @@ WaveSchedule
 			WaitBeforeStarting 10
 			WaitBetweenSpawns 3
 
-			RandomChoice
-			{
 				TFBot
 				{
 					Class Pyro
@@ -2862,7 +2860,7 @@ WaveSchedule
 					Skill Expert
 					Item "The Dragon's Fury"
 
-					EventChangeAttributes	// thx seel (>w< )
+					EventChangeAttributes	// thx seel (>w< ) //thx therealscroob for fixing an issue similar to this in a completely different mission which helped me here.
 					{
 						Default	// shoot the tank
 						{
@@ -2873,8 +2871,8 @@ WaveSchedule
 								WaitWhenDone 1
 								Delay 0.1
 								Repeats 0
-								Cooldown 1
-								Duration 0.1
+								Cooldown 2 //1 //fix
+								Duration 2 //0.1 //fix
 								KillAimTarget 1
 								OnDoneChangeAttributes Bots
 							}
@@ -2885,7 +2883,6 @@ WaveSchedule
 						}
 					}
 				}
-			}
 		}
 	}
 


### PR DESCRIPTION
w4:
Fixed Dragon Furry Pyros idling in spawn until the tank dies, instead of focusing the tank. Tank HP increased from 15k to 20k to "compensate" for this. (beforehand, the pyros would actually solo it if you dealt with the bots)