### PR TITLE
Fix __potato_RespawnThink function doing nothing

### DIFF
--- a/scripts/vscripts/mapspawn.nut
+++ b/scripts/vscripts/mapspawn.nut
@@ -1,43 +1,67 @@
-
-::__potato_hiderespawntext <- 0.0;
+// Globals
+::__potato_hiderespawntext <- 1;
 
 ::GlobalFixes <- {
+    // Callback runs on first wave init
     function OnGameEvent_teamplay_round_start(params)
     {
+        // Fixes for Bronx
         if (GetMapName() == "mvm_bronx_rc2")
         {
+            // Fix poor performance caused by Bone Followers being enabled on animated Engiebot models
             for (local props; props = Entities.FindByClassname(props, "prop_dynamic");)
+            {
                 if (props.GetModelName() == "models/bots/engineer/bot_engineer.mdl")
-                    NetProps.SetPropInt(props, "m_BoneFollowerManager.m_iNumBones", 0)
-
+                {
+                    NetProps.SetPropInt(props, "m_BoneFollowerManager.m_iNumBones", 0);
+                }
+            }
+            // Fix death pit not killing ubered players
             for (local deathpit; deathpit = Entities.FindByClassname(deathpit, "trigger_hurt");)
+            {
                 if (deathpit.GetName() != "trigger_hurt_hatch_fire")
                 {
-                    NetProps.SetPropInt(deathpit, "m_bitsDamageInflict", 1048576)  //DMG_ACID
-                    EntFireByHandle(deathpit, "SetDamage", "10000", -1, null, null)
+                    NetProps.SetPropInt(deathpit, "m_bitsDamageInflict", 1048576);  // DMG_CRITICAL
+                    EntFireByHandle(deathpit, "SetDamage", "10000", -1, null, null);
                 }
-        }
-        local playermanager = Entities.FindByClassname(null, "tf_player_manager")
-        if (playermanager.GetScriptThinkFunc() != "" || __potato_hiderespawntext > 0.0) return
-        ::__potato_RespawnThink <- function()
-        {
-            for (local player, i = 1; i < MaxClients().tointeger(); i++)
-            {
-                try
-                    if (player = PlayerInstanceFromIndex(i) && !IsPlayerABot(player) && NetProps.GetPropInt(player, "m_lifeState") != 0 && GetPropFloatArray(playermanager, "m_flNextRespawnTime", i) > 99.0)
-                        SetPropFloatArray(playermanager, "m_flNextRespawnTime", __potato_hiderespawntext, player.entindex())
-                catch(err) break
             }
-            return -1
         }
-        playermanager.ValidateScriptScope()
-        playermanager.GetScriptScope().__RespawnThink <- __RespawnThink
-        AddThinkToEnt(playermanager, "__RespawnThink")
+
+        local tf_player_manager = Entities.FindByClassname(null, "tf_player_manager");
+        if (tf_player_manager.GetScriptThinkFunc() != "") return;   // Do not reapply think if already applied
+        local tf_gamerules =  Entities.FindByClassname(null, "tf_gamerules");
+
+        // Hide respawn times if they are arbitrarily high
+        // ====================================================================
+        // FOR MISSION MAKERS: You can disable this behaviour for your mission!
+        // Simply fire this output to do so:
+		//  Target worldspawn
+		//  Action RunScriptCode
+		//  Param  "__potato_hiderespawntext = 0"
+        function __potato_RespawnThink()
+        {
+            for (local i = 1; i <= MaxClients().tointeger(); i++)
+            {
+                local player = PlayerInstanceFromIndex(i);
+                if (__potato_hiderespawntext == 1 &&                    // Is fix is enabled?
+                    player != null && !IsPlayerABot(player) &&          // Is player is valid?
+                    NetProps.GetPropInt(player, "m_lifeState") == 2 &&  // Is player is dead?
+                    NetProps.GetPropFloatArray(tf_gamerules, "m_TeamRespawnWaveTimes", player.GetTeam()) > 99.0)    // Does respawn wave time exceed 99s?
+                {
+                    // This can be set to 1.0s to instead show 'Respawn in: Prepare to Respawn'
+                    NetProps.SetPropFloatArray(tf_player_manager, "m_flNextRespawnTime", 0.0, i);  
+                }
+            }
+            return -1;
+        }
+
+        // Add think function to tf_player_manager
+        // Note: If a mission clears the thinks on tf_player_manager this script will fail
+        tf_player_manager.ValidateScriptScope();
+        tf_player_manager.GetScriptScope().__potato_RespawnThink <- __potato_RespawnThink;
+        AddThinkToEnt(tf_player_manager, "__potato_RespawnThink");
     }
 }
 
-__CollectGameEventCallbacks(GlobalFixes)
-
-// SpawnEntityFromTable("trigger_hurt", {
-
-// })
+// Register callbacks
+__CollectGameEventCallbacks(GlobalFixes);


### PR DESCRIPTION
This pull request:
- Compares against `m_TeamRespawnWaveTimes` instead of `m_flNextRespawnTime`.
  - Setting `m_flNextRespawnTime` causes it to become a junk value for the map duration, causing comparison to always return true after the first and bleed over in to other missions on the same map.
- Modifies __potato_hiderespawntext so mission makers can disable it by setting it to 0.
  - Seems more intuitive (personal opinion).
- Fixes assorted bugs that made `__potato_RespawnThink` do nothing.
  - Fixed missing `NetProps.` method prefixes.
  - Fixed error thrown by `player.entindex()`.
    - Replaced occurrence with `for` index number, but the original error was caused by inline declaration of `local player` in the `if` statement.
  - Added test for null player and modified alive state test.
    - Previously would return true, as invalid players were checked and a return value of -1 incorrectly passed the original `NetProps.GetPropInt(player, "m_lifeState") != 0` test.
  - Fixed incorrect references to the non-existent function `__RespawnThink`.
- Adds code comments to be more descriptive for any curious fellows.