### PR TITLE
Sntr request: Bauernhof update

### DIFF
--- a/scripts/population/mvm_shadows_b3_adv_bauernhof.pop
+++ b/scripts/population/mvm_shadows_b3_adv_bauernhof.pop
@@ -11,13 +11,16 @@
 // - Kevin Sherwood			> Music used on this mission
 // - Kirillian 				> Super Zombie Fortress models for the Special enemies
 // - Hell-met 				> You wouldn't believe how much Trespasser spiritually inspired this mission
-// - Eve 					> Player tracking logic
+// - Eve/Elizabeth 			> Player tracking logic
+// - Seelpit				> Logic for replacing round counter by moving the round number to the wave counter
 // - Skin King 				> For finding out every possible way you can think of to cheese the mission with godspots
 // - Yaki 					> Logic help for the cash mechanic + gun dumpster
 // - Lite 					> Timer logic (repurposed into the round counter) also icons for zombies, Tank and Battlelord
 // - Royal					> For pretty much all the .lua scripting this mission uses
 // - Washy					> The other side of all the .lua, ie. Action key check for machines + dumpster
+// - Mince					> Some assistance making the revive logic not suck eggs
 // - DaMno 					> Reference for COD Zombies and how things work in it
+// - Whurr					> Finetuned the navigation file and put up with long analyze times on Shadows
 // - NotYourSagittarius		> Classicons for Special Enemies
 // - Rexy 					> Made the vending machine model used here
 // - Emotive 				> The alternate version of Abracadavre used for the mission end jingle
@@ -46,11 +49,11 @@ WaveSchedule
 	FixedRespawnWaveTime 1
 	CanBotsAttackWhileInSpawnRoom	yes
 	EventPopfile Halloween
-//	ZombiesNoWave666 1
+	ZombiesNoWave666 1
 	
-	NoReanimators 1
+//	NoReanimators 1
 	NoRomevisionCosmetics 1
-	NoMvMDeathTune 1
+//	NoMvMDeathTune 1			// give some clue that a teammate dies?
 	FixedBuybacks 1
 	BuybacksPerWave 0
 	TextPrintTime 5
@@ -60,7 +63,7 @@ WaveSchedule
 	NoJoinMidwave 1
 	RobotLimit 26
 	MaxSpectators 0
-//	MaxRedPlayers 4
+//	MaxRedPlayers 5  // 4
 	ForceHoliday 2
 //	SentryBusterFriendlyFire 0
 	DisplayRobotDeathNotice 0
@@ -73,12 +76,14 @@ WaveSchedule
 	ExtendedUpgradesOnly 1
 	UpgradeStationKeepWeapons 1 // stop players from losing perks
 	RespecEnabled 0 // fix refund exploit
+	DefaultMiniBossScale 1.5 // shrink bosses and the like, done to fix pathing issues with the house
 
 
 //	DisableSound "MVM.BotStep"
 	DisableSound "MVM.SentryBusterIntro"
 	DisableSound "Weapon_Upgrade.ExplosiveHeadshot" // really loud with groups!!
 	DisableSound "music.mvm_lost_wave" // this works now
+	DisableSound "music.mvm_end_last_wave" // this works now
 	DisableSound "Game.YourTeamWon"
 	DisableSound "heavy_mvm_giant_robot01"								 
 	DisableSound "heavy_mvm_giant_robot02"								 
@@ -100,6 +105,7 @@ WaveSchedule
 	DisableSound "medic_mvm_sentry_buster02"
 	DisableSound "Announcer.MVM_All_Dead"
 	
+	PrecacheModel "models/weapons/c_models/c_soldier_arms_rocketless.mdl"
 	PrecacheModel "models/weapons/c_models/c_packer.mdl"
 	PrecacheModel "models/weapons/c_models/c_mp40/c_mp40.mdl"
 	PrecacheModel "models/weapons/c_models/c_tgat/c_tgat.mdl"
@@ -275,9 +281,9 @@ WaveSchedule
 		"Heavy.M_MVM_Cheers07"	 shadows/tank_yell_07.mp3
 		"Heavy.M_MVM_Cheers08"	 shadows/tank_yell_08.mp3
 		"Heavy.M_MVM_NeedDispenser01"	 shadows/tank_fire_01.mp3 // angry pootis
-		"Heavy.M_MVM_NiceShot01"	 shadows/tank_throw_01.mp3
-		"Heavy.M_MVM_NiceShot02"	 shadows/tank_throw_02.mp3
-		"Heavy.M_MVM_NiceShot03"	 shadows/tank_throw_03.mp3
+//		"Heavy.M_MVM_NiceShot01"	 shadows/tank_throw_01.mp3
+//		"Heavy.M_MVM_NiceShot02"	 shadows/tank_throw_02.mp3
+//		"Heavy.M_MVM_NiceShot03"	 shadows/tank_throw_03.mp3
 		"Heavy.M_MVM_No01"			 shadows/rip_up_rock_1.mp3
 		"Heavy.M_MVM_No02"			 shadows/rip_up_rock_1.mp3
 		"Heavy.M_MVM_No03"			 shadows/rip_up_rock_1.mp3
@@ -335,6 +341,10 @@ WaveSchedule
 		"Pyro.M_MVM_Jeers02"  	shadows/gas_idle_04.mp3
 	//	"Pyro.M_MVM_Cheers01"  	shadows/gas_idle_01.mp3
 	//	"Pyro.M_MVM_No01"  		shadows/gas_idle_02.mp3 // oh pyro why are you like this
+		"demoman_mvm_resurrect04" "vo/demoman_thanksfortheteleporter02.mp3" // replaced Revive lines to omit medic thanks to reviving being an Action command too
+		"engineer_mvm_resurrect01" "vo/engineer_thanksfortheteleporter01.mp3"
+		"heavy_mvm_resurrect03" "vo/heavy_positivevocalization03.mp3"
+		"sniper_mvm_resurrect04" "vo/sniper_thanksfortheteleporter01.mp3"
 	}
 	ItemBlacklist
 	{
@@ -383,7 +393,6 @@ WaveSchedule
 		Name "The Kritzkrieg"
 		Name "The Quick-Fix" // stock only
 		Name "The Eyelander"
-		Name "Festive Eyelander"
 		Name "The Widowmaker"
 		Name "Panic Attack Shotgun"
 		Name "Nessie's Nine Iron"
@@ -411,16 +420,14 @@ WaveSchedule
 		Name "The Cozy Camper"
 		Name "Darwin's Danger Shield"
 		Name "The Crusader's Crossbow"
-		Name "Festive Crusader's Crossbow"
 		Name "The Short Circuit"
-//		Name "The Flying Guillotine"
+		Name "The Flying Guillotine"
 		Name "The Iron Bomber"
 		Name "The Loch-n-Load"
 //		Name "The Equalizer"
 		Name "The Escape Plan"
 		Name "The Disciplinary Action"
 		Name "Gloves of Running Urgently"
-		Name "Festive Gloves of Running Urgently"
 		Name "The Eviction Notice"
 		Name "The Powerjack"
 		Name "Ali Baba's Wee Booties"
@@ -431,7 +438,7 @@ WaveSchedule
 	// weapon specific tweaks
     ItemAttributes
     {
-        ItemName "Bonk! Atomic Punch" //for the vending machine animation
+        ItemName "Bonk! Atomic Punch" // for the vending machine animation
         "deploy time increased" 99
     }
 	ItemAttributes
@@ -450,7 +457,7 @@ WaveSchedule
 	{
 		ItemName "The Crusader's Crossbow"
 		"sniper no headshots" 0
-		"damage bonus HIDDEN" 4
+		"damage bonus HIDDEN" 4 // crossbow can keep its damage stats because it's the crossbow
 		"reload full clip at once" 1
 	}
 	ItemAttributes
@@ -463,19 +470,14 @@ WaveSchedule
 	ItemAttributes
 	{
 		ItemName "The Shortstop"
-		"damage bonus HIDDEN" 4
+		"damage bonus HIDDEN" 2
 	}
 	ItemAttributes
 	{
 		ItemName "Pretty Boy's Pocket Pistol"
 		"provide on active" 1
 		"can headshot" 1
-		"damage bonus HIDDEN" 3
-	}
-	ItemAttributes 
-	{
-		ItemName "The Righteous Bison"
-		"CARD: damage bonus" 1.5
+		"damage bonus HIDDEN" 1.5
 	}
 	ItemAttributes
 	{
@@ -486,23 +488,23 @@ WaveSchedule
 	ItemAttributes
 	{
 		Classname tf_weapon_scattergun
-		"damage bonus HIDDEN" 4
+		"damage bonus HIDDEN" 3
 	}
 	ItemAttributes // surprisingly many weapons use this
 	{
 		Classname tf_weapon_pistol
-		"damage bonus HIDDEN" 3
+		"damage bonus HIDDEN" 1.5
 	}
 	ItemAttributes // surprisingly many weapons use this
 	{
 		Classname tf_weapon_handgun_scout_secondary
-		"damage bonus HIDDEN" 3
+		"damage bonus HIDDEN" 1.5
 		"can headshot" 1
 	}
 	ItemAttributes // for medic only
 	{
 		ItemName "the black box"
-		"hidden primary max ammo bonus" 0.3
+	//	"hidden primary max ammo bonus" 0.3 // test later but for now, redact this as well
 		"fire rate bonus" 0.001
 		"projectile spread angle penalty" 2
 		"damage bonus HIDDEN" 2.5
@@ -512,43 +514,43 @@ WaveSchedule
 	ItemAttributes // explosives do a lot to compensate for no headshots
 	{
 		Classname tf_weapon_rocketlauncher
-		"damage bonus HIDDEN" 6
+		"damage bonus HIDDEN" 5
 		"blast dmg to self increased" 0.25
 		"self dmg push force decreased" 0.15
 	}
 	ItemAttributes // surprisingly many weapons use this
 	{
 		Classname tf_weapon_shotgun
-		"damage bonus HIDDEN" 4
+		"damage bonus HIDDEN" 3
 	}
 	ItemAttributes // for medic only
 	{
 		ItemName "the nostromo napalmer"
-		"hidden primary max ammo bonus" 6.25
-		"damage bonus HIDDEN" 3
+//		"hidden primary max ammo bonus" 6.25  // originally needed due to limitations rafmod has now fixed
+		"damage bonus HIDDEN" 2
 	}
 	ItemAttributes // fire indeed hot!
 	{
 		Classname tf_weapon_flamethrower
-		"damage bonus HIDDEN" 3
-		"hidden primary max ammo bonus" 0.5
+		"damage bonus HIDDEN" 2
+//		"hidden primary max ammo bonus" 0.5
 	}
 	ItemAttributes // super hot
 	{
 		Classname tf_weapon_rocketlauncher_fireball
-		"damage bonus HIDDEN" 3.5
+		"damage bonus HIDDEN" 3
 	}
 	ItemAttributes // explosives do a lot to compensate for no headshots
 	{
 		Classname tf_weapon_grenadelauncher 
-		"damage bonus HIDDEN" 5.5
+		"damage bonus HIDDEN" 4.5
 		"blast dmg to self increased" 0.25
 		"self dmg push force decreased" 0.15
 	}
 	ItemAttributes // explosives do a lot to compensate for no headshots
 	{
 		Classname tf_weapon_pipebomblauncher
-		"damage bonus HIDDEN" 5.5
+		"damage bonus HIDDEN" 4.5
 		"blast dmg to self increased" 0.25
 		"self dmg push force decreased" 0.15
 	}
@@ -556,44 +558,31 @@ WaveSchedule
 	{
 		Classname tf_weapon_minigun
 		"damage bonus HIDDEN" 1.5
-		"aiming movespeed decreased" 0.0025
+//		"aiming movespeed decreased" 0.0025 // doesn't work on pyro so lets not single out heavy
 	}
 	ItemAttributes // needs this to work
 	{
-		Classname tf_weapon_smg
+		Classname tf_weapon_smg // guns are pretty batshit insane here
 		"revolver use hit locations" 1
-		"hidden secondary max ammo penalty" 4.5 // needs more ammo due to shotgun-classes also being able to roll this
-		"damage bonus HIDDEN" 3 // guns are pretty batshit insane here
+	//	"hidden secondary max ammo penalty" 4.5 // needed more ammo due to shotgun-classes also being able to roll this, obsolete due to later updates
+		"damage bonus HIDDEN" 2 // smg can keep its damage nerfs
 	}
 	ItemAttributes
 	{
 		Classname tf_weapon_sniperrifle
-		"damage bonus HIDDEN" 5 // I'M A BLOODY GOD, MATE
+		"damage bonus HIDDEN" 4 // I'M A BLOODY GOD, MATE
 	}
 	ItemAttributes
 	{
 		Classname tf_weapon_compound_bow
-		"damage bonus HIDDEN" 3
+		"damage bonus HIDDEN" 2
 	}
 	ItemAttributes // needs this to work
 	{
 		Classname tf_weapon_charged_smg
 		"revolver use hit locations" 1
-		"hidden secondary max ammo penalty" 4.5
-		"damage bonus HIDDEN" 3.2
-	}
-	ItemAttributes
-	{
-		Classname tf_weapon_revolver
-		"damage bonus HIDDEN" 3
-		"revolver use hit locations" 1
-	}
-	ItemAttributes // spy has the strongest melee weapon
-	{
-		Classname tf_weapon_knife
-		"armor piercing" 50
-		"damage bonus HIDDEN" 3.75 // should be 150?
-		"dmg max health" 0.05 // spy deserves it because he's pretty rough to play with his limited kit
+//		"hidden secondary max ammo penalty" 4.5
+		"damage bonus HIDDEN" 2.2
 	}
 	ItemAttributes
 	{
@@ -695,6 +684,8 @@ WaveSchedule
 		"move accuracy mult" 1.33
 		"duck accuracy mult" 0.5
 		"mult_patient_overheal_penalty_active" 0.5
+		"use original class weapon animations" 1 // test
+		"health regen" 5 // that's right, WE'RE DOING IT??
 		Scout
 		{
 			"min respawn time" 4444 // disable scout's quick respawn
@@ -708,6 +699,7 @@ WaveSchedule
 			"can headshot" 1
 			"hidden maxhealth non buffed" -100
 			"move speed penalty" 1.16
+			"custom view model" "models/weapons/c_models/c_soldier_arms_rocketless.mdl"
 		}
 		Pyro
 		{
@@ -735,7 +727,8 @@ WaveSchedule
 			"bidirectional teleport" 1
 			"can headshot" 1
 			"move speed penalty" 0.93
-			"hidden secondary max ammo penalty" 0.2 // wtf why do you have so much ammo
+		//	"hidden secondary max ammo penalty" 0.5 // wtf why do you have so much ammo
+		// this now applies to EVERY secondary engie uses due to rafmod changes, comment it out
 		}
 		Medic
 		{
@@ -743,6 +736,7 @@ WaveSchedule
 			"hidden maxhealth non buffed" -50
 			"move speed penalty" 0.875
 			"no primary ammo from dispensers while active" 1
+			"health regen" 0 // medic doesn't get the regen buff, they already have one
 		}
 		Sniper
 		{
@@ -772,7 +766,7 @@ WaveSchedule
 			"custom weapon fire sound" "=80|shadows/hubby_shoot.mp3"
 			"provide on active" 1
 			"clip size penalty" 0.5
-			"damage bonus HIDDEN" 8
+			"damage bonus HIDDEN" 5
 			"explosive bullets" 116
 			"fire rate penalty" 1.25
 			"blast dmg to self increased" 0.1 // lower self damage?
@@ -801,7 +795,7 @@ WaveSchedule
 			"custom weapon reload sound" "Weapon_DoubleBarrel.TubeClose"
 			"fire full clip at once" 1
 			"reload full clip at once" 1
-			"damage bonus HIDDEN" 4
+			"damage bonus HIDDEN" 3
 			"mod max primary clip override" 2
 			"reload time increased" 1.5
 			"custom kill icon" force_a_nature
@@ -811,7 +805,7 @@ WaveSchedule
 		"The Ray Gun"
 		{
 			OriginalItemName "The C.A.P.P.E.R"
-			"damage bonus HIDDEN" 11
+			"damage bonus HIDDEN" 8
 			"explosive bullets" 116
 			"fire rate penalty" 1.5
 			"mod max primary clip override" 20
@@ -828,11 +822,11 @@ WaveSchedule
 			"custom weapon fire sound" "Weapon_ShootingStar.SingleCharged"
 			"custom kill icon" pomson
 			"sniper fires tracer" 1
-			"fire rate bonus HIDDEN" 2
-			"projectile penetration heavy" 1
+			"fire rate bonus HIDDEN" 1.6
+			"projectile penetration heavy" 2
 			"reload full clip at once" 1
 			"reload time increased" 1.65
-			"damage bonus HIDDEN" 11
+			"damage bonus HIDDEN" 13
 			"mod max primary clip override" 5
 			"ragdolls become ash" 1
 			"can headshot" -1
@@ -844,7 +838,7 @@ WaveSchedule
 			"custom item model" "models\weapons\c_models\c_tgat\c_tgat.mdl"
 			"fire rate bonus HIDDEN" 0.8
 			"reload time increased" 1
-			"damage bonus HIDDEN" 4
+			"damage bonus HIDDEN" 3
 			"mod max primary clip override" 9
 			"burst fire count" -3
 			"burst fire rate mult" 2.5
@@ -855,13 +849,13 @@ WaveSchedule
 		{
 			OriginalItemName TF_WEAPON_SYRINGEGUN_MEDIC
 			"override projectile type" 1 // bullet
-			"damage bonus HIDDEN" 4.5
+			"damage bonus HIDDEN" 4
 			"fire rate bonus HIDDEN" 1.1
 			"custom item model" "models\weapons\c_models\c_mp40\c_mp40.mdl"
 			"custom weapon fire sound" Weapon_SMG.Single // maybe this won't be fucking loud!!
 			"custom kill icon" smg
 			"mod max primary clip override" 15
-			"hidden primary max ammo bonus" 0.5
+			"hidden primary max ammo bonus" 0.6
 			"health drain medic" -3
 			"can headshot" 1
 		}
@@ -871,7 +865,7 @@ WaveSchedule
 			"custom item model" "models\weapons\c_models\c_packer.mdl"
 			"reload time increased hidden" 0.75
 			"panic_attack" 1
-			"damage bonus HIDDEN" 3.5
+			"damage bonus HIDDEN" 2.5
 			"fire rate bonus HIDDEN" 0.5
 			"mod max primary clip override" 4
 			"auto fires full clip" 1
@@ -889,31 +883,8 @@ WaveSchedule
 			"reload time increased" 1.25
 			"weapon spread bonus" 0
 			"mod max primary clip override" 25
-			"damage bonus HIDDEN" 3 // single pellet only, so needs a bit more damage
-		}
-		// spy-only weapons because spy is built different
-		"Big Iron"
-		{
-			OriginalItemName "TF_WEAPON_REVOLVER"
-			"custom item model" "models/workshop/weapons/c_models/c_ttg_sam_gun/c_ttg_sam_gun.mdl"
-			"custom kill icon" samrevolver
-			"fire rate bonus HIDDEN" 0.9
-			"mod max primary clip override" 12
-			"damage bonus HIDDEN" 3.5 // single pellet only, so needs a bit more damage
-		}
-		"SMG_Spy"
-		{
-			OriginalItemName "TF_WEAPON_REVOLVER"
-			"custom item model" "models/weapons/c_models/c_smg/c_smg.mdl"
-			"custom weapon reload sound" "Weapon_Revolver.WorldReload"
-			"custom weapon fire sound" Weapon_SMG.Single
-			"custom kill icon" smg
-			"fire rate bonus HIDDEN" 0.25
-			"reload time increased" 1.25
-			"weapon spread bonus" 0
-			"mod max primary clip override" 25
-			"hidden secondary max ammo penalty" 3
-		//	"damage bonus HIDDEN" 2 // single pellet only, so needs a bit more damage
+			"hidden primary max ammo bonus" 0.5
+			"damage bonus HIDDEN" 2 // single pellet only, so needs a bit more damage
 		}
 		"BRAINS"
 		{
@@ -959,19 +930,53 @@ WaveSchedule
 		"Great Gatsby" // pistol
 		{
 			OriginalItemName "Upgradeable TF_WEAPON_PISTOL"
-			"damage bonus" 5
+			"damage bonus" 3
 			"maxammo secondary increased" 2.5
 			"paintkit_proto_def_index" 296 
 			"set_item_texture_wear" 0
 			"cannot be upgraded" 1
 		}
+		"Frammilizer" // beam rifle
+		{
+			OriginalItemName TF_WEAPON_SHOTGUN_HWG
+			"bullets per shot bonus" 0.5
+			"custom item model" "models/workshop/weapons/c_models/c_drg_pomson/c_drg_pomson.mdl"
+			"custom weapon fire sound" "Weapon_ShootingStar.SingleCharged"
+			"custom kill icon" pomson
+			"sniper fires tracer" 1
+			"fire rate bonus HIDDEN" 1.3
+			"projectile penetration heavy" 4
+			"reload full clip at once" 1
+			"reload time increased" 1.3
+			"damage bonus" 14
+			"mod max primary clip override" 10
+			"ragdolls become ash" 1
+			"can headshot" -1
+			"cannot be upgraded" 1
+		}
+		"Soviet Slammer" // tgat
+		{
+			OriginalItemName TF_WEAPON_SHOTGUN_HWG
+			"bullets per shot bonus" 1.25
+			"custom item model" "models\weapons\c_models\c_tgat\c_tgat.mdl"
+			"fire rate bonus" 0.5
+			"faster reload rate" 0.6
+			"damage bonus" 4
+			"mod max primary clip override" 18
+			"burst fire count" -6
+			"burst fire rate mult" 2
+			"maxammo secondary increased" 2
+			"weapon spread bonus" 0.5
+			"can headshot" 1
+			"cannot be upgraded" 1
+		}
 		"The Pinch Hitter" // Shortstop
 		{
 			OriginalItemName "The Shortstop"
-			"damage bonus" 5
+			"damage bonus" 3
 			"mod max primary clip override" 12
 			"maxammo primary increased" 4
-			"fire rate bonus" 0.3
+			"fire rate bonus" 0.5
 			"faster reload rate" 0.6
 			"paintkit_proto_def_index" 296 
 			"set_item_texture_wear" 0
@@ -985,7 +990,7 @@ WaveSchedule
 			"custom weapon reload sound" "Weapon_DoubleBarrel.TubeClose"
 			"fire full clip at once" 1
 			"reload full clip at once" 1
-			"damage bonus" 5
+			"damage bonus" 4
 			"bullets per shot bonus" 2
 			"fire rate bonus" 0.8
 			"mod max primary clip override" 2
@@ -1004,7 +1009,7 @@ WaveSchedule
 			OriginalItemName "Upgradeable TF_WEAPON_SCATTERGUN"
 			"paintkit_proto_def_index" 296 
 			"set_item_texture_wear" 0
-			"damage bonus" 6
+			"damage bonus" 4
 			"bullets per shot bonus" 2
 			"fire rate bonus" 0.6
 			"faster reload rate" 0.75
@@ -1016,7 +1021,7 @@ WaveSchedule
 			OriginalItemName "The Force-a-Nature"
 			"paintkit_proto_def_index" 296 
 			"set_item_texture_wear" 0
-			"damage bonus" 6
+			"damage bonus" 4
 			"bullets per shot bonus" 1.5
 			"fire rate bonus" 0.8
 			"faster reload rate" 0.8
@@ -1031,7 +1036,7 @@ WaveSchedule
 			"paintkit_proto_def_index" 296 
 			"set_item_texture_wear" 0
 			"cannot be upgraded" 1
-			"damage bonus" 7.5
+			"damage bonus" 6
 			"fire rate bonus" 0.6
 			"faster reload rate" -0.8
 			"maxammo primary increased" 3
@@ -1045,12 +1050,11 @@ WaveSchedule
 			OriginalItemName "Upgradeable TF_WEAPON_SHOTGUN_PRIMARY"
 			"paintkit_proto_def_index" 296 
 			"set_item_texture_wear" 0
-			"damage bonus" 5
+			"damage bonus" 4
 			"bullets per shot bonus" 2
 			"fire rate bonus" 1.3
 			"faster reload rate" 0.75
-			"apply z velocity on damage" 112
-			"apply look velocity on damage" 256
+			"damage causes airblast" 1
 			"maxammo secondary increased" 2.5
 			"cannot be upgraded" 1
 		}
@@ -1061,8 +1065,10 @@ WaveSchedule
 			"attach particle effect" 2
 			"paintkit_proto_def_index" 296 
 			"set_item_texture_wear" 0
-			"damage bonus" 8
-			"maxammo primary increased" 1.25
+			"damage bonus" 4
+			"damage bonus vs burning" 3 // apparently functions just like damage bonus, the check is goofy
+			"mult_item_meter_charge_rate" 0.8
+			"maxammo primary increased" 2.5
 			"cannot be upgraded" 1
 		}
 		"Face Melter" // flamethrower
@@ -1072,7 +1078,7 @@ WaveSchedule
 			"set_item_texture_wear" 0
 			"damage bonus" 3
 			"dmg penalty vs players" 3
-			"maxammo primary increased" 2
+			"maxammo primary increased" 4
 			"cannot be upgraded" 1
 		}
 		"Burning Love" // shotgun
@@ -1080,8 +1086,8 @@ WaveSchedule
 			OriginalItemName "Upgradeable TF_WEAPON_SHOTGUN_PRIMARY" // normal one is engineer-only but THIS ONE is multiclass????
 			"paintkit_proto_def_index" 296 
 			"set_item_texture_wear" 0
-			"damage bonus" 2
-			"dmg penalty vs players" 3
+			"damage bonus" 3
+			"dmg penalty vs players" 2
 			"bullets per shot bonus" 1.5
 			"fire rate bonus" 0.9
 			"faster reload rate" 0.75
@@ -1096,10 +1102,10 @@ WaveSchedule
 			OriginalItemName "Upgradeable TF_WEAPON_GRENADELAUNCHER"
 			"clip size penalty" 0.2
 			"grenade explode on impact" 1
-			"damage bonus" 16
+			"damage bonus" 13
 			"fire rate bonus" 2.5
 			"dmg falloff decreased" 0.5
-			"maxammo primary reduced" 0.8
+			"maxammo primary reduced" 0.7
 			"explosion particle" hightower_explosion
 			"custom projectile model" "models\weapons\w_models\w_atomball_blu.mdl" // nice
 			"custom impact sound" "misc/doomsday_missile_explosion.wav"
@@ -1113,7 +1119,7 @@ WaveSchedule
 		"The Cactus Blast" // stickies
 		{
 			OriginalItemName "Upgradeable TF_WEAPON_PIPEBOMBLAUNCHER"
-			"damage bonus" 8
+			"damage bonus" 5.5
 			"maxammo secondary increased" 3
 			"Blast radius increased" 1.5
 			"fire rate bonus" 0.15
@@ -1134,22 +1140,24 @@ WaveSchedule
 			"bullets per shot bonus" 2
 			"maxammo primary increased" 2.5
 			"paintkit_proto_def_index" 296 
-			"aiming movespeed decreased" 0.0025
+	//		"aiming movespeed decreased" 0.0025 // does not work on pyro, apparently this is heavy-only
 			"penetrate teammates" 1
 			"set_item_texture_wear" 0
 			"cannot be upgraded" 1
 		}
-		"The Grand Slam" // shotgun
+		"Big Boris" // shotgun, renamed because funny
 		{
 			OriginalItemName "Upgradeable TF_WEAPON_SHOTGUN_PRIMARY"
-			"fire rate bonus" 2.5
+			"provide on active" 1
+			"fire rate bonus" 2
 			"bullets per shot bonus" 10
 			"paintkit_proto_def_index" 296
 			"maxammo secondary increased" 2
 			"penetrate teammates" 1
-			"damage bonus" 2.5
+			"damage bonus" 3
 			"reload full clip at once" 1
 			"set_item_texture_wear" 0
+			"hand scale" 1.5
 			"cannot be upgraded" 1
 		}
 		// engineer
@@ -1160,7 +1168,7 @@ WaveSchedule
 			"special item description" "Cannot headshot"
 			"override projectile type"  1
 			"sniper fires tracer" 1
-			"damage bonus" 7.5
+			"damage bonus" 6
 			"bullets per shot bonus" 3
 			"penetrate teammates" 1
 			"projectile penetration heavy" 1
@@ -1172,30 +1180,28 @@ WaveSchedule
 			"custom weapon fire sound" "=80|weapons/cow_mangler_explosion_charge_04.wav"
 		}
 		// medic
-		"DNA Rejuvenator" // syringe gun
+		"DNA Rejuvenator" // whatever medic melee. used to be primary
 		{
-			OriginalItemName "Upgradeable TF_WEAPON_SYRINGEGUN_MEDIC"
+			OriginalItemName "Upgradeable TF_WEAPON_BONESAW"
 			"special item description" "Invasively resurrects a Zombie"
 			"special item description 2" "Target dies after 5 seconds"
-			"maxammo primary reduced" 0.2
-			"clip size penalty" 0.5
-			"fire rate penalty" 3
 			"damage penalty" 0.1
+			"custom item model" "models/workshop/weapons/c_models/c_uberneedle/c_uberneedle.mdl"
 			"fire input on hit" "popscript^$rejuvenatorHit^"
 			"paintkit_proto_def_index" 296 
 			"set_item_texture_wear" 0
 			"cannot be upgraded" 1
 			"special damage type" 1
-			"penetrate teammates" 1
 		}
 		"Durchbohren" // crossbow?
 		{
-			"damage bonus" 13
+			OriginalItemName "The Crusader's Crossbow"
+			"damage bonus" 6
 			"special item description" "Piercing enemies grants extra damage"
 			"clip size upgrade atomic" 5
 			"projectile penetration" 1
 			"fire rate bonus" 0.2
-			"penetration damage penalty" 1.25
+			"penetration damage penalty" 1.5
 			"custom item model" "models/workshop/weapons/c_models/c_crusaders_crossbow/c_crusaders_crossbow_xmas.mdl"
 			"paintkit_proto_def_index" 296 
 			"set_item_texture_wear" 0
@@ -1206,10 +1212,10 @@ WaveSchedule
 		"The Love Tap" // sniper rifle
 		{
 			OriginalItemName "Upgradeable TF_WEAPON_SNIPERRIFLE"
-			"damage bonus" 5
+			"damage bonus" 8
 			"projectile penetration heavy" 2
 			"headshot damage increase" 3
-			"maxammo primary increased" 1.5
+			"maxammo primary increased" 3
 			"SRifle Charge rate increased" 3
 			"penetrate teammates" 1
 			"paintkit_proto_def_index" 296 
@@ -1221,7 +1227,7 @@ WaveSchedule
 			OriginalItemName "The Huntsman"
 			"dmg penalty vs players" 8
 			"arrow mastery" 3
-			"maxammo primary increased" 1.5
+			"maxammo primary increased" 3
 	//		"projectile penetration" 1  // oops the arrow does the fucky wucky
 			"penetrate teammates" 1
 			"paintkit_proto_def_index" 296 
@@ -1229,43 +1235,6 @@ WaveSchedule
 			"cannot be upgraded" 1
 		}
 		// spy
-		"Sally"
-		{
-			OriginalItemName "TF_WEAPON_REVOLVER" // the one item that doesn't refpose spy
-			"custom item model" "models/weapons/c_models/c_revolver/c_revolver.mdl"
-			"custom weapon fire sound" "Weapon_Revolver.Single"
-			"custom weapon reload sound" "Weapon_Revolver.WorldReload"
-			"bullets per shot bonus" 0.25
-			"mod max primary clip override" 12
-			"maxammo primary increased" 2.5
-			"custom kill icon" revolver
-			"damage bonus" 15
-			"override projectile type" 2 
-			"projectile speed increased" 2
-			"blast dmg to self increased" 0.1
-			"projectile trail particle" bullet_distortion_trail
-			"custom projectile model" "models/weapons/w_models/w_rocketbullet.mdl"
-			"paintkit_proto_def_index" 296 
-			"set_item_texture_wear" 0
-			"cannot be upgraded" 1
-		}
-		"Kingpin"
-		{
-			OriginalItemName "The Shortstop" // the one item that doesn't refpose spy
-			"custom item model" "models/weapons/c_models/c_ambassador/c_ambassador_xmas.mdl"
-			"custom weapon fire sound" "Weapon_Ambassador.Single"
-			"custom weapon reload sound" "Weapon_Revolver.WorldReload"
-			"custom kill icon" ambassador
-			"bullets per shot bonus" 0.25
-			"maxammo primary increased" 2.5
-			"fire rate bonus HIDDEN" 1.5
-			"mod max primary clip override" 12
-			"damage bonus" 20 // single pellet only, so needs a bit more damage
-			"headshot damage increase" 6
-			"paintkit_proto_def_index" 296 
-			"set_item_texture_wear" 0
-			"cannot be upgraded" 1
-		}
 	}
 	ExtraLoadoutItems // in here so the dumpster can call them into your pockets
 	{
@@ -1639,44 +1608,6 @@ WaveSchedule
 				Hidden 1
 			}
 		}
-		Spy
-		{
-			Secondary
-			{
-				Item TF_WEAPON_SMG
-				Hidden 1
-			}
-			Secondary
-			{
-				Item TF_WEAPON_PISTOL
-				Hidden 1
-			}
-			Primary
-			{
-				Item "Primary Ambassador"
-				Hidden 1
-			}
-			Primary
-			{
-				Item "Big Iron"
-				Hidden 1
-			}
-			Secondary
-			{
-				Item TF_WEAPON_SHOTGUN_PYRO
-				Hidden 1
-			}
-			Secondary
-			{
-				Item "The Winger"
-				Hidden 1
-			}
-			Secondary
-			{
-				Item "The Ray Gun"
-				Hidden 1
-			}
-		}
 	}
 	ExtendedUpgrades
 	{
@@ -1736,7 +1667,6 @@ WaveSchedule
 				ItemName "Darwin's Danger Shield"
 				ItemName "The Cozy Camper"
 				ItemName "Thunder Gun"
-				SimilarToItem "The Flying Guillotine"
 			}
 		}
 		WU_Clipsize_Soldemo
@@ -1758,10 +1688,10 @@ WaveSchedule
 		}
 		WU_Firerate
 		{
-			Name "+10% fire rate"
+			Name "+15% fire rate" // changed due to rounding error with +10%
 			Attribute "fire rate bonus"
-			Increment -0.1
-			Cap 0.7
+			Increment -0.15
+			Cap 0.55
 			Cost 200
 			Tier 1
 			AllowedWeapons
@@ -1792,15 +1722,14 @@ WaveSchedule
 				ItemName "Darwin's Danger Shield"
 				ItemName "The Cozy Camper"
 				ItemName Tactigatling
-				SimilarToItem "The Flying Guillotine"
 			}
 		}
 		WU_FirerateTgat
 		{
-			Name "+10% fire rate"
+			Name "+15% fire rate"
 			Attribute "fire rate bonus"
-			Increment -0.1
-			Cap 0.6
+			Increment -0.15
+			Cap 0.55
 			Cost 200
 			Tier 1
 			AllowedWeapons
@@ -1827,7 +1756,6 @@ WaveSchedule
 				ItemName "Ali Baba's Wee Booties"
 				ItemName "The Bootlegger"
 				ItemName "Thunder Gun"
-				SimilarToItem "The Flying Guillotine"
 			}
 		}
 		WU_AmmoSecond
@@ -1860,7 +1788,6 @@ WaveSchedule
 				ItemName "The Razorback"
 				ItemName "Darwin's Danger Shield"
 				ItemName "The Cozy Camper"
-				SimilarToItem "The Flying Guillotine"
 			}
 		}
 		WU_Revspeed
@@ -1912,7 +1839,6 @@ WaveSchedule
 				ItemName "Darwin's Danger Shield"
 				ItemName "The Cozy Camper"
 				ItemName "Thunder Gun"
-				SimilarToItem "The Flying Guillotine"
 			}
 		}
 		WU_MedicRange
@@ -2174,10 +2100,10 @@ WaveSchedule
 	//	}
 		WU_PaP_T3_Generic // for guns that don't support skins save for DF
 		{
-			Name "+50% Damage bonus"
+			Name "+100% Damage bonus"
 			Attribute "dmg penalty vs players"
-			Increment 0.5
-			Cap 1.5
+			Increment 1
+			Cap 2
 			Cost 5000
 			Tier 2
 			AllowedWeapons
@@ -2200,7 +2126,7 @@ WaveSchedule
 				ItemName TF_WEAPON_PIPEBOMBLAUNCHER
 				ItemName TF_WEAPON_PISTOL
 				ItemName TF_WEAPON_SNIPERRIFLE
-				Classname tf_weapon_syringegun_medic
+		//		Classname tf_weapon_syringegun_medic
 				Classname tf_weapon_bat_giftwrap
 				Classname tf_weapon_sniperrifle
 				Classname tf_weapon_medigun
@@ -2216,6 +2142,8 @@ WaveSchedule
 				ItemName "The Crusader's Crossbow"
 				ItemName "The Force-a-Nature"
 				ItemName "Thunder Gun"
+				ItemName "Tactigatling"
+				ItemName "Das Maschinenpistole" // has its own for some reason but lets just accept it
 			}
 			OnApply
 			{
@@ -2287,6 +2215,42 @@ WaveSchedule
 			OnApply
 			{
 				Output "!activator,$giveitem,The Gut Wrecker,0"
+				Output "!activator,speakresponseconcept,TLK_MVM_LOOT_ULTRARARE,0,-1"
+			}
+		}
+		WU_PaP_T3_BRifle
+		{
+			Name "Überweapon Upgrade"
+			Attribute "dmg penalty vs players"
+			Increment 1
+			Cap 2
+			Cost 5000
+			Tier 2
+			AllowedWeapons
+			{
+				ItemName "Beam Rifle"
+			}
+			OnApply
+			{
+				Output "!activator,$giveitem,Frammilizer,0"
+				Output "!activator,speakresponseconcept,TLK_MVM_LOOT_ULTRARARE,0,-1"
+			}
+		}
+		WU_PaP_T3_BRifle
+		{
+			Name "Überweapon Upgrade"
+			Attribute "dmg penalty vs players"
+			Increment 1
+			Cap 2
+			Cost 5000
+			Tier 2
+			AllowedWeapons
+			{
+				ItemName "Tactigatling"
+			}
+			OnApply
+			{
+				Output "!activator,$giveitem,Soviet Slammer,0"
 				Output "!activator,speakresponseconcept,TLK_MVM_LOOT_ULTRARARE,0,-1"
 			}
 		}
@@ -2502,7 +2466,7 @@ WaveSchedule
 			}
 			OnApply
 			{
-				Output "!activator,$giveitem,The Grand Slam,0"
+				Output "!activator,$giveitem,Big Boris,0"
 				Output "!activator,speakresponseconcept,TLK_MVM_LOOT_ULTRARARE,0,-1"
 			}
 		}
@@ -2524,29 +2488,29 @@ WaveSchedule
 				Output "!activator,speakresponseconcept,TLK_MVM_LOOT_ULTRARARE,0,-1"
 			}
 		}
-		WU_PaP_T3_Syringegun
-		{
-			Name "Überweapon Upgrade"
-			Attribute "dmg penalty vs players"
-			Increment 1
-			Cap 2
-			Cost 5000
-			Tier 2
-			AllowedWeapons
-			{
-				Classname tf_weapon_syringegun_medic
-			}
-			DisallowedWeapons
-			{
-				ItemName "Primary SMG"
-				ItemName "Das Maschinenpistole"
-			}
-			OnApply
-			{
-				Output "!activator,$giveitem,DNA Rejuvenator,0"
-				Output "!activator,speakresponseconcept,TLK_MVM_LOOT_ULTRARARE,0,-1"
-			}
-		}
+	//	WU_PaP_T3_Syringegun // obsolete, rejuvenator is not a primary anymore
+	//	{
+	//		Name "Überweapon Upgrade"
+	//		Attribute "dmg penalty vs players"
+	//		Increment 1
+	//		Cap 2
+	//		Cost 5000
+	//		Tier 2
+	//		AllowedWeapons
+	//		{
+	//			Classname tf_weapon_syringegun_medic
+	//		}
+	//		DisallowedWeapons
+	//		{
+	//			ItemName "Primary SMG"
+	//			ItemName "Das Maschinenpistole"
+	//		}
+	//		OnApply
+	//		{
+	//			Output "!activator,$giveitem,DNA Rejuvenator,0"
+	//			Output "!activator,speakresponseconcept,TLK_MVM_LOOT_ULTRARARE,0,-1"
+	//		}
+	//	}
 		WU_PaP_T3_Crossbow
 		{
 			Name "Überweapon Upgrade"
@@ -2845,6 +2809,22 @@ WaveSchedule
 			{
 				targetname navman
 			}
+			func_button
+			{
+				origin "2168 40 13604"
+				mins "-12 -10 -6"
+				maxs "24 10 6"
+				rendermode 10
+				movedir "0 180 0"
+				spawnflags 513
+				damagefilter filter_redteam
+				speed 5
+				wait 20
+				sounds 3
+				targetname revive_button
+				
+				OnPressed "popscript,$revivelogic,!activator,0,-1"
+			}
 			game_forcerespawn
 			{
 				targetname respawner
@@ -2879,6 +2859,7 @@ WaveSchedule
 				OnTrigger "fog_controller,SetStartDist,600,,-1"
 				OnTrigger "fog_controller,SetEndDist,4000,,-1"
 				OnTrigger "fog_controller,SetColor,0 0 0,,-1"
+				OnTrigger "tf_objective_resource,$SetClientProp$m_nMannVsMachineWaveCount,0,,-1" // go back to zero when map resets
 			}
 			math_counter
             {
@@ -3145,7 +3126,7 @@ WaveSchedule
 			{
 				targetname stage_start
 				"OnTrigger" "powerup_timer,Enable,,0,-1"
-				"OnTrigger" "roundtext,AddOutput,color 255 65 65:0:-1"
+		//		"OnTrigger" "roundtext,AddOutput,color 255 65 65:0:-1"
 				"OnTrigger" "roundcounter,add,1,0,-1"
 				"OnTrigger" "realtimer,trigger,,0,-1"
 				"OnTrigger" "realtimer,trigger,,0.23,-1"
@@ -3165,7 +3146,7 @@ WaveSchedule
 				"OnTrigger" "relay_enemycount_reset,Trigger,,-1"
 				"OnTrigger" "medicbonus_relay,Trigger,,-1"
 				"OnTrigger" "respawner,ForceTeamRespawn,2,0.7,-1"
-				"OnTrigger" "roundtext,AddOutput,color 222 222 222:0:-1" // lets give it a go
+		//		"OnTrigger" "roundtext,AddOutput,color 222 222 222:0:-1" // lets give it a go
 				"OnTrigger" "realtimer,trigger,,0.23,-1"
 				"OnTrigger" "powerup_timer,Disable,,0,-1"
 				"OnTrigger" "hologram_*,Disable,,0,-1"
@@ -3179,7 +3160,7 @@ WaveSchedule
 				"OnTrigger" "relay_enemycount_reset,Trigger,,-1"
 				"OnTrigger" "medicbonus_relay,Trigger,,-1"
 				"OnTrigger" "respawner,ForceTeamRespawn,2,0.7,-1"
-				"OnTrigger" "roundtext,AddOutput,color 222 222 222:0:-1" // lets give it a go
+		//		"OnTrigger" "roundtext,AddOutput,color 222 222 222:0:-1" // lets give it a go
 				"OnTrigger" "realtimer,trigger,,0.23,-1"
 				"OnTrigger" "powerup_timer,Disable,,0,-1"
 				"OnTrigger" "hologram_*,Disable,,0,-1"
@@ -3235,7 +3216,7 @@ WaveSchedule
 				targetname bossstage_start
 				"OnTrigger" "door_red_large_win_*,Close,,0,-1"
 				"OnTrigger" "red_spawn_warp,Enable,,0,-1"
-				"OnTrigger" "roundtext,AddOutput,color 255 65 65:0:-1"
+		//		"OnTrigger" "roundtext,AddOutput,color 255 65 65:0:-1"
 				"OnTrigger" "roundcounter,add,1,0,-1"
 				"OnTrigger" "realtimer,trigger,,0,-1"
 				"OnTrigger" "realtimer,trigger,,0.23,-1"
@@ -3259,7 +3240,7 @@ WaveSchedule
 				targetname bossstage_start_tread
 				"OnTrigger" "door_red_large_win_*,Close,,0,-1"
 				"OnTrigger" "red_spawn_warp,Enable,,0,-1"
-				"OnTrigger" "roundtext,AddOutput,color 255 65 65:0:-1"
+		//		"OnTrigger" "roundtext,AddOutput,color 255 65 65:0:-1"
 				"OnTrigger" "roundcounter,add,1,0,-1"
 				"OnTrigger" "realtimer,trigger,,0,-1"
 				"OnTrigger" "realtimer,trigger,,0.23,-1"
@@ -3285,7 +3266,7 @@ WaveSchedule
 				"OnTrigger" "tankround_snd,volume,0,0,-1"
 				"OnTrigger" "bossfight_snd,volume,0,0,-1"
 				"OnTrigger" "bossround_music,volume,0,0,-1"
-				"OnTrigger" "roundtext,AddOutput,color 222 222 222:0:-1" // lets give it a go
+		//		"OnTrigger" "roundtext,AddOutput,color 222 222 222:0:-1" // lets give it a go
 				"OnTrigger" "realtimer,trigger,,0.23,-1"
 				"OnTrigger" "powerup_timer,Disable,,0,-1"
 				"OnTrigger" "hologram_*,Disable,,0,-1"
@@ -3676,6 +3657,20 @@ WaveSchedule
 				maxs "106 288 26"
 				origin "-738 -1622 18"
 			}
+			func_nav_avoid // the two slopes at the sides of the pit
+			{
+				tags bigguyalert
+				mins "-140 -20 -132"
+				maxs "140 20 132"
+				origin "-644 -492 -124"
+			}
+			func_nav_avoid // the two slopes at the sides of the pit
+			{
+				tags bigguyalert
+				mins "-140 -20 -132"
+				maxs "140 20 132"
+				origin "-644 492 -124"
+			}
 			func_nav_avoid // jump spot, the boxes near stables
 			{
 				tags bigguyalert
@@ -3815,6 +3810,70 @@ WaveSchedule
 				mins "-194 -608 -414"
 				maxs "194 608 414"
 				origin "128 -1856 900"
+			}
+			func_forcefield // clipping for THAT spot on the barn
+			{
+				StartDisabled 0
+				TeamNum 3
+				mins "-96 -143 -412"
+				maxs "96 143 412"
+				origin "416 -1392 900"
+			}
+			func_forcefield // next to the grain silo
+			{
+				StartDisabled 0
+				TeamNum 3
+				mins "-84 -143 -12"
+				maxs "84 143 12"
+				origin "428 -1392 476"
+			}
+			func_forcefield // with a thin roof, so instead of a few blockers like normal
+			{
+				StartDisabled 0
+				TeamNum 3
+				mins "-72 -143 -12"
+				maxs "72 143 12"
+				origin "440 -1392 452"
+			}
+			func_forcefield // we have to do SEVERAL small blockers
+			{
+				StartDisabled 0
+				TeamNum 3
+				mins "-64 -143 -12"
+				maxs "64 143 12"
+				origin "448 -1392 428"
+			}
+			func_forcefield // because otherwise it would block movement on the other side
+			{
+				StartDisabled 0
+				TeamNum 3
+				mins "-52 -143 -12"
+				maxs "52 143 12"
+				origin "460 -1392 404"
+			}
+			func_forcefield // which is why PTs are not a good way to fix map problems such as this one
+			{
+				StartDisabled 0
+				TeamNum 3
+				mins "-44 -143 -12"
+				maxs "44 143 12"
+				origin "468 -1392 380"
+			}
+			func_forcefield
+			{
+				StartDisabled 0
+				TeamNum 3
+				mins "-44 -143 -12"
+				maxs "44 143 12"
+				origin "477 -1392 356"
+			}
+			func_forcefield
+			{
+				StartDisabled 0
+				TeamNum 3
+				mins "-44 -143 -12"
+				maxs "44 143 12"
+				origin "486 -1392 332"
 			}
 		}
 		Pushblocks // all the pushing to stop godspots because customnav can't fix them all
@@ -4193,6 +4252,7 @@ WaveSchedule
 				mins "-96 -16 -124"
 				maxs "96 16 124"
 			}
+			
 			trigger_push // harvester near stables
 			{
 				pushdir "0 270 0"
@@ -4334,7 +4394,29 @@ WaveSchedule
             {
                 "$OnKilled" "playersLeftAlive,Subtract,1,0,0"
             }
+			OnParentKilledOutput
+            {
+                Target "popscript"
+                Action "$spawn_revive_marker"
+            }
         }
+		Revivemarker // port from Titanium Thieves
+		{
+		//	NoFixup 1
+			trigger_multiple
+			{
+				targetname revive_trigger
+				mins "-36 -36 -36"
+				maxs "36 36 36"
+				spawnflags 1
+				OnStartTouch "!activator,$DisplayTextCenter,Hold Action key to revive your teammate,0,-1"
+			}
+			OnParentKilledOutput
+			{
+				Target "revive_trigger"
+				Action "DisableAndEndTouch"
+			}
+		}
 		EnemyTracker // shoot enemy, get money
 		{
 			OnParentKilledOutput // avoid stacking outputs
@@ -4844,7 +4926,7 @@ WaveSchedule
 			training_annotation
             {
 				"targetname"   "hints_11"
-				"display_text" "Powerups have a chance to drop from zombies during rounds."
+				"display_text" "Powerups have a chance to drop from zombies during waves."
 				"lifetime"     "4"
 				"origin" "328 -150 52" 
             }
@@ -5031,6 +5113,7 @@ WaveSchedule
 				OnTrigger "!activator,$PlaySoundToSelf,shadows/perk_usesfx.mp3,0,-1"
 				OnTrigger "vm_jugsfx,PlaySound,0,2.2,-1"
 				OnTrigger "!activator,$AddPlayerAttribute,max health additive bonus|150,2.2,-1"
+			//	OnTrigger "!activator,$AddPlayerAttribute,health regen|15,2.2,-1"			// nice idea but too good
 				OnTrigger "!activator,$PlaySoundToSelf,weapons/buffed_on.wav,2.2,-1"
 				OnTrigger "!activator,$DisplayTextCenter,Perk Bonus activated: Extra max health!,2.2,-1"
 				OnTrigger "!activator,SpeakResponseConcept,TLK_PLAYER_SPELL_PICKUP_RARE,2.45,-1"
@@ -5292,6 +5375,7 @@ WaveSchedule
 				OnTrigger "!activator,$RemoveCurrency,2000,-1" // testing
 				OnTrigger "!activator,$PlaySoundToSelf,shadows/perk_usesfx.mp3,0,-1"
 				OnTrigger "vm_dtsfx,PlaySound,0,2.2,-1"
+				OnTrigger "!activator,$AddPlayerAttribute,mult_item_meter_charge_rate|0.67,-1"
 				OnTrigger "!activator,$AddPlayerAttribute,fire rate bonus|0.67,-1"
 				OnTrigger "!activator,$PlaySoundToSelf,weapons/buffed_on.wav,2.2,-1"
 				OnTrigger "!activator,$DisplayTextCenter,Perk Bonus activated: Increased fire rate!,2.2,-1"
@@ -5400,98 +5484,6 @@ WaveSchedule
 				OnTrigger "!activator,SpeakResponseConcept,TLK_PLAYER_SPELL_PICKUP_RARE,2.45,-1"
 			}
 		}
-		Vending_Flop // Steelshin Lager
-		{
-			NoFixup 1
-			prop_dynamic
-			{
-				origin "0 0 50" // ??
-				disableshadows 0
-				model "models/props_misc/vending_machine_01.mdl"
-				solid 6
-				skin 0 // red
-				targetname vm_flop
-			}
-			prop_dynamic
-			{
-				origin "-0 -0 148" // ??
-				angles "0 270 0"
-				disableshadows 0
-				model "models/player/items/all_class/cowboyboots_soldier.mdl"
-				modelscale 2
-				solid 0
-				parentname vm_flop
-			}
-			func_button
-			{
-				origin "0 -12 128"
-				targetname vm_flopbutton
-				parentname vm_flop
-				damagefilter filter_flopmulti
-				rendermode 10
-				movedir "0 180 0"
-				spawnflags 513
-				speed 5
-				wait 3
-				sounds 3
-				mins "-24 -8 -44"
-				maxs "24 8 44"
-				
-				OnPressed "perkbuff_flop,trigger,0,-1" // testing
-				OnPressed "filter_flopmoney,TestActivator,0,-1"
-			}
-			$filter_sendprop
-            {
-                targetname filter_flopmoney
-                $name m_nCurrency
-				negated 0
-                $value 1000
-                $compare "greater than or equal"
-            }
-			filter_multi
-			{
-				targetname filter_flopmulti
-				filtertype 0
-				negated 0
-				filter01 filter_flopmoney
-				filter02 filter_melee
-				OnFail "!activator,$PlaySoundToSelf,buttons/button8.wav,0,-1"
-			}
-			trigger_multiple
-			{
-				origin "0 0 50"
-				targetname vm_flopmsg
-				parentname vm_flop
-				filtername filter_redteam
-				spawnflags 1
-				mins "-128 -128 0"
-				maxs "128 128 128"
-				
-				OnStartTouchAll "!activator,$DisplayTextCenter,Hold Action key to buy Steelshin Lager for $1000,0,-1"
-			}
-		//	ambient_generic
-		//	{
-		//		targetname vm_flopsfx
-		//		spawnflags 48
-		//		health 10 // this is volume
-		//		radius 15000
-		//		pitch 100
-		//		message "shadows/perk_flop.mp3"
-		//		parentname vm_flop
-		//	}
-			logic_relay
-			{
-				targetname perkbuff_flop
-				OnTrigger "!activator,$RemoveCurrency,1000,-1"
-				OnTrigger "!activator,$PlaySoundToSelf,shadows/perk_usesfx.mp3,0,-1"
-		//		OnTrigger "vm_flopsfx,PlaySound,0,2.2,-1"
-		//		OnTrigger "!activator,$AddPlayerAttribute,cancel falling damage|1,-1"
-				OnTrigger "!activator,$AddPlayerAttribute,blast dmg to self increased|0,-1"
-				OnTrigger "!activator,$PlaySoundToSelf,weapons/buffed_on.wav,2.2,-1"
-				OnTrigger "!activator,$DisplayTextCenter,Perk Bonus activated: Self damage immunity!,2.2,-1"
-				OnTrigger "!activator,SpeakResponseConcept,TLK_PLAYER_SPELL_PICKUP_RARE,2.45,-1"
-			}
-		}
 		Roundtimer // where we at
 		{
 			NoFixup 1
@@ -5501,7 +5493,7 @@ WaveSchedule
 				Action SetValue
 				Param 0
 			}
-			game_text
+			game_text // obsolete but kept since removing it causes lua problems
 			{
 				"targetname" "roundtext"
 				"color" "255 65 65" 	// 222 222 222 breaktime color
@@ -5543,6 +5535,7 @@ WaveSchedule
 				"targetname" "roundcounter"
 				"max" "255" // lol you'll never get to round 255
 				"outvalue" "roundformat,$setkey$case01,,0,-1"
+				"OutValue" "tf_objective_resource,$SetClientProp$m_nMannVsMachineWaveCount,,0,-1" // test
 				"outvalue" "gameoverformat,$setkey$case01,,0,-1"
 			}
 			math_counter
@@ -5564,8 +5557,8 @@ WaveSchedule
 			{
 				"targetname" "roundformat"
 				"case16" "Round %" // who knows, maybe this is how it works
-				"ondefault" "roundtext,$setkey$message,,0,-1"
-				"ondefault" "roundtext,display,0,0,-1"
+		//		"ondefault" "roundtext,$setkey$message,,0,-1"
+		//		"ondefault" "roundtext,display,0,0,-1"
 			}
 			logic_relay
 			{
@@ -8128,7 +8121,7 @@ WaveSchedule
 				"fxtime" "8" // how 
 				"holdtime" "30"
 				"spawnflags" "1"
-				"channel" 2
+				"channel" 4
 				"effect" 2
 				"x" "0.4"
 				"y" "0.37"
@@ -8136,7 +8129,7 @@ WaveSchedule
 			logic_case
 			{
 				"targetname" "gameoverformat"
-				"case16" "You survived % rounds" // who knows, maybe this is how it works
+				"case16" "You survived % waves" // who knows, maybe this is how it works
 				"ondefault" "gameovertext,$setkey$message,,0,-1"
 				"ondefault" "gameovertext,display,0,0,-1"
 			}
@@ -8177,6 +8170,10 @@ WaveSchedule
 				spawnflags 1
 				rendercolor "0 0 0"
 			}
+			point_populator_interface
+			{
+				targetname populator
+			}
 			logic_relay
 			{
 				targetname gameover
@@ -8184,6 +8181,7 @@ WaveSchedule
 			//	"OnTrigger" "roundtext,AddOutput,color 0 0 0:3:-1"
 				"OnTrigger" "youwin,Disable,,1.5,-1"
 				"OnTrigger" "LMA,Disable,,3,-1"
+				"OnTrigger" "populator,PauseBotSpawning,,3,-1"
 				"OnTrigger" "player,$PlaySequence,victory,3,-1"
 				"OnTrigger" "bossstage_start,CancelPending,,3,-1"
 				"OnTrigger" "bossstage_start_tread,CancelPending,,3,-1"
@@ -8199,6 +8197,7 @@ WaveSchedule
 				"OnTrigger" "fail_snd,PlaySound,,3,-1"
 				"OnTrigger" "fade_out,Fade,,6,-1"
 				"OnTrigger" "camera_gameover_1,$EnableAll,,8,-1"
+				"OnTrigger" "entity_revive_marker,Kill,,8,-1"
 				"OnTrigger" "camera_spin,start,,8,-1"
 				"OnTrigger" "player,$PlaySequence,victoryb,8,-1"
 				"OnTrigger" "fade_in,Fade,,8,-1"
@@ -8223,6 +8222,7 @@ WaveSchedule
 				"OnTrigger" "win_snd,PlaySound,,0,-1"
 				"OnTrigger" "fade_out,Fade,,13,-1"
 				"OnTrigger" "camera_gameover_1,$EnableAll,,15,-1"
+				"OnTrigger" "entity_revive_marker,Kill,,15,-1"
 				"OnTrigger" "camera_spin,start,,15,-1"
 				"OnTrigger" "fade_in,Fade,,15,-1"
 				"OnTrigger" "fade_out,Fade,,20,-1"
@@ -8232,27 +8232,6 @@ WaveSchedule
 				"OnTrigger" "fade_in,Fade,,22,-1"
 				"OnTrigger" "hologram_nuke_hurt,Enable,,25.5,-1"
 				"OnTrigger" "camera_spin_2,stop,,32,-1"
-			}
-		}
-		SpyPlayerPt // give Spy guns
-		{
-	//		OnSpawnOutput
-	//		{
-	//			Target !activator
-	//			Action $giveitem
-	//			Param "Primary Revolver" // fake revolver because his actual revolver causes problems
-	//		}
-	//		OnSpawnOutput
-	//		{
-	//			Target !activator
-	//			Action $giveitem
-	//			Param "Secondary Revolver" // ditto
-	//		}
-			OnSpawnOutput // I forgot what is this for but I don't want to touch it
-			{
-				Target !activator
-				Action StripItemSlot
-				Param 4
 			}
 		}
 		FrearmPT // bodygroup shit
@@ -8405,11 +8384,6 @@ WaveSchedule
 	SpawnTemplate "DumpsterSpawner"
 	PlayerSpawnTemplate
 	{
-		Name SpyPlayerPt
-		Class Spy
-	}
-	PlayerSpawnTemplate
-	{
 		Name MedicbagPT
 		Class Medic
 		Bone "prp_backpack" //Player bone where the template would be positioned
@@ -8486,7 +8460,7 @@ WaveSchedule
 				"dmg taken from crit reduced" 0.7
 			}
 		}
-		T_Zombie_Sniper
+		T_Zombie_Sniper // there's just one now, ease up on the sound overrides (people MIGHT crash less now)
 		{
 			Class Sniper
 			Skill Expert
@@ -8685,6 +8659,7 @@ WaveSchedule
 				"airblast vulnerability multiplier" 0
 				"force distribute currency on death" 1
 				"dmg taken from crit reduced" 0.7
+				"dmg taken mult from special damage type 1" -1
 			}
 		}
 		T_Zombie_Special_Burner
@@ -8761,6 +8736,7 @@ WaveSchedule
 				"mult stun resistance" 0
 				"force distribute currency on death" 1
 				"dmg taken from crit reduced" 0.7
+				"dmg taken mult from special damage type 1" -1
 			}
 		}
 		T_Zombie_Special_Hulk
@@ -8800,7 +8776,7 @@ WaveSchedule
 				Delay 2
 				Cooldown 4.2
 				Repeats 0
-				IfSeeTarget 0
+				IfNoTarget 1
 				Type "Move Up"
 			}
 			VoiceCommand
@@ -8830,7 +8806,8 @@ WaveSchedule
 			{
 				ItemName TF_WEAPON_SHOTGUN_HWG
 				"provide on active" 1
-				"is invisible" 1
+				"custom item model" models\props_forest\cliff_wall_09a.mdl
+				"attachment name" "debris"
 				"single wep deploy time increased" 1.5
 				"override projectile type" 2
 				"fire rate bonus" 20
@@ -8841,10 +8818,10 @@ WaveSchedule
 				"custom projectile model" models\props_forest\cliff_wall_09a.mdl
 				"damage bonus" 16.7
 				"dmg bonus vs buildings" 4444
-				"custom impact sound" shadows/thrown_projectile_hit_01.mp3
+				"custom impact sound" =100|shadows/thrown_projectile_hit_01.mp3
 				"custom weapon fire sound" misc/null.wav
-				"projectile gravity" 300
-				"projectile speed increased" 1.7
+				"projectile gravity" 150
+				"projectile speed increased" 1.5
 				"blast radius increased" 1.25
 				"custom kill icon" mailbox
 				"rocket specialist" 1
@@ -8959,6 +8936,7 @@ WaveSchedule
 				"cannot be sapped" 1
 				"force distribute currency on death" 1
 				"dmg taken from crit reduced" 0.7
+				"dmg taken mult from special damage type 1" -1
 			}
 		}
 		T_Zombie_Special_Crawler // he flops and he hops
@@ -9028,6 +9006,7 @@ WaveSchedule
 				"cannot be sapped" 1
 				"force distribute currency on death" 1
 				"dmg taken from crit reduced" 0.7
+				"dmg taken mult from special damage type 1" -1
 			}
 		}
 		T_Zombie_Special_Superfist
@@ -9055,6 +9034,7 @@ WaveSchedule
 				Delay 15
 				Cooldown 5
 				Repeats 0
+				IfNoTarget 1
 				Type "Move up"
 			}
 			VoiceCommand
@@ -9096,6 +9076,7 @@ WaveSchedule
 				"cannot be sapped" 1
 				"force distribute currency on death" 1
 				"dmg taken from crit reduced" 0.7
+				"dmg taken mult from special damage type 1" -1
 			}
 		}
 		T_Zombie_Special_Corroder
@@ -9190,6 +9171,7 @@ WaveSchedule
 				"increased jump height" 1.3
 				"force distribute currency on death" 1
 				"dmg taken from crit reduced" 0.7
+				"dmg taken mult from special damage type 1" -1
 			}
 		}
 		T_Robot_Boss_Treadkill // spawns in round 20
@@ -9203,6 +9185,7 @@ WaveSchedule
 			Action Mobber
 			MaxVisionRange 1500 // used for turret
 			ClassIcon tank
+			Tag bigguyalert
 			Attributes UseBossHealthBar
 			Attributes DisableDodge
 			ExtAttr IgnoreBuildings
@@ -9400,6 +9383,7 @@ WaveSchedule
 			Health 64843 // 25000 base hp
 	//		Scale 2.4
 			Action Mobber
+			Tag bigguyalert
 			StripItem "Zombie Heavy"
 			Attributes UseBossHealthBar
 			Attributes DisableDodge
@@ -9519,7 +9503,7 @@ WaveSchedule
 			}
 			CharacterAttributes
 			{
-				"move speed bonus"	0.35
+				"move speed bonus"	0.42
 				"voice pitch scale" 0
 				"cancel falling damage" 1
 				"damage force reduction" 0
@@ -9544,6 +9528,8 @@ WaveSchedule
 	{
 		WaitWhenDone	65
 		Checkpoint	Yes
+	//	CustomWaveNumber 0
+		CustomMaxWaveNumber 0
 		
 		StartWaveOutput
 		{
@@ -9564,7 +9550,7 @@ WaveSchedule
 		Explanation
  	 	{
 			Line "{yellow}Take on the hordes of the undead."
-			Line "{yellow}Clear 20 rounds to win!"
+			Line "{yellow}Clear 20 waves to win!"
 		}
 		
 		SpawnTemplate "Pushblocks" // in here so 'corelogic' doesn't delete them while wiping Shadows things
@@ -9607,12 +9593,6 @@ WaveSchedule
 			Origin "-19 1893 156"
 			Angles "0 0 0"
 		}
-	//	SpawnTemplate
-	//	{
-	//		Name "Vending_Flop"
-	//		Origin "129 -1307 206"
-	//		Angles "0 0 0"
-	//	}
 		WaveSpawn
 		{
 			Name "stage_01"
@@ -10122,6 +10102,11 @@ WaveSchedule
 				TFBot
 				{
 					Template T_Zombie_Special_Hulk
+					ItemAttributes
+					{
+						ItemName TF_WEAPON_SHOTGUN_HWG
+						"custom weapon fire sound" =100|shadows/tank_throw_01.mp3
+					}
 					Taunt
 					{
 						Delay 0
@@ -10170,14 +10155,6 @@ WaveSchedule
 						Type "Primary"
 						IfHealthBelow 6000
 					}
-					VoiceCommand // throw rock
-					{
-						Delay 12.5
-						Cooldown 20
-						Repeats 0
-						Type "Nice Shot"
-						IfHealthBelow 6000
-					}
 					WeaponSwitch
 					{
 						Delay 13.5
@@ -10198,6 +10175,11 @@ WaveSchedule
 				TFBot
 				{
 					Template T_Zombie_Special_Hulk
+					ItemAttributes
+					{
+						ItemName TF_WEAPON_SHOTGUN_HWG
+						"custom weapon fire sound" =100|shadows/tank_throw_02.mp3
+					}
 					DeathSound shadows\tank_death_02.mp3
 					Taunt
 					{
@@ -10247,14 +10229,6 @@ WaveSchedule
 						Type "Primary"
 						IfHealthBelow 6000
 					}
-					VoiceCommand // throw rock
-					{
-						Delay 12.5
-						Cooldown 20
-						Repeats 0
-						Type "Nice Shot"
-						IfHealthBelow 6000
-					}
 					WeaponSwitch
 					{
 						Delay 13.5
@@ -10275,6 +10249,11 @@ WaveSchedule
 				TFBot
 				{
 					Template T_Zombie_Special_Hulk
+					ItemAttributes
+					{
+						ItemName TF_WEAPON_SHOTGUN_HWG
+						"custom weapon fire sound" =100|shadows/tank_throw_03.mp3
+					}
 					DeathSound shadows\tank_death_03.mp3
 					Taunt
 					{
@@ -10322,14 +10301,6 @@ WaveSchedule
 						Cooldown 20
 						Repeats 0
 						Type "Primary"
-						IfHealthBelow 6000
-					}
-					VoiceCommand // throw rock
-					{
-						Delay 12.5
-						Cooldown 20
-						Repeats 0
-						Type "Nice Shot"
 						IfHealthBelow 6000
 					}
 					WeaponSwitch
@@ -10734,6 +10705,11 @@ WaveSchedule
 				TFBot
 				{
 					Template T_Zombie_Special_Hulk
+					ItemAttributes
+					{
+						ItemName TF_WEAPON_SHOTGUN_HWG
+						"custom weapon fire sound" =100|shadows/tank_throw_01.mp3
+					}
 					Health 9680
 					Taunt
 					{
@@ -10783,14 +10759,6 @@ WaveSchedule
 						Type "Primary"
 						IfHealthBelow 8417
 					}
-					VoiceCommand // throw rock
-					{
-						Delay 12.5
-						Cooldown 20
-						Repeats 0
-						Type "Nice Shot"
-						IfHealthBelow 8417
-					}
 					WeaponSwitch
 					{
 						Delay 13.5
@@ -10811,6 +10779,11 @@ WaveSchedule
 				TFBot
 				{
 					Template T_Zombie_Special_Hulk
+					ItemAttributes
+					{
+						ItemName TF_WEAPON_SHOTGUN_HWG
+						"custom weapon fire sound" =100|shadows/tank_throw_02.mp3
+					}
 					Health 9680
 					DeathSound shadows\tank_death_02.mp3
 					Taunt
@@ -10861,14 +10834,6 @@ WaveSchedule
 						Type "Primary"
 						IfHealthBelow 8417
 					}
-					VoiceCommand // throw rock
-					{
-						Delay 12.5
-						Cooldown 20
-						Repeats 0
-						Type "Nice Shot"
-						IfHealthBelow 8417
-					}
 					WeaponSwitch
 					{
 						Delay 13.5
@@ -10889,6 +10854,11 @@ WaveSchedule
 				TFBot
 				{
 					Template T_Zombie_Special_Hulk
+					ItemAttributes
+					{
+						ItemName TF_WEAPON_SHOTGUN_HWG
+						"custom weapon fire sound" =100|shadows/tank_throw_03.mp3
+					}
 					Health 9680
 					DeathSound shadows\tank_death_03.mp3
 					Taunt
@@ -10937,14 +10907,6 @@ WaveSchedule
 						Cooldown 20
 						Repeats 0
 						Type "Primary"
-						IfHealthBelow 8417
-					}
-					VoiceCommand // throw rock
-					{
-						Delay 12.5
-						Cooldown 20
-						Repeats 0
-						Type "Nice Shot"
 						IfHealthBelow 8417
 					}
 					WeaponSwitch
@@ -11305,6 +11267,11 @@ WaveSchedule
 				TFBot
 				{
 					Template T_Zombie_Special_Hulk
+					ItemAttributes
+					{
+						ItemName TF_WEAPON_SHOTGUN_HWG
+						"custom weapon fire sound" =100|shadows/tank_throw_01.mp3
+					}
 					Health 15590
 					Taunt
 					{
@@ -11354,14 +11321,6 @@ WaveSchedule
 						Type "Primary"
 						IfHealthBelow 13556
 					}
-					VoiceCommand // throw rock
-					{
-						Delay 12.5
-						Cooldown 20
-						Repeats 0
-						Type "Nice Shot"
-						IfHealthBelow 13556
-					}
 					WeaponSwitch
 					{
 						Delay 13.5
@@ -11382,6 +11341,11 @@ WaveSchedule
 				TFBot
 				{
 					Template T_Zombie_Special_Hulk
+					ItemAttributes
+					{
+						ItemName TF_WEAPON_SHOTGUN_HWG
+						"custom weapon fire sound" =100|shadows/tank_throw_02.mp3
+					}
 					Health 15590
 					DeathSound shadows\tank_death_02.mp3
 					Taunt
@@ -11432,14 +11396,6 @@ WaveSchedule
 						Type "Primary"
 						IfHealthBelow 13556
 					}
-					VoiceCommand // throw rock
-					{
-						Delay 12.5
-						Cooldown 20
-						Repeats 0
-						Type "Nice Shot"
-						IfHealthBelow 13556
-					}
 					WeaponSwitch
 					{
 						Delay 13.5
@@ -11460,6 +11416,11 @@ WaveSchedule
 				TFBot
 				{
 					Template T_Zombie_Special_Hulk
+					ItemAttributes
+					{
+						ItemName TF_WEAPON_SHOTGUN_HWG
+						"custom weapon fire sound" =100|shadows/tank_throw_03.mp3
+					}
 					Health 15590
 					DeathSound shadows\tank_death_03.mp3
 					Taunt
@@ -11508,14 +11469,6 @@ WaveSchedule
 						Cooldown 20
 						Repeats 0
 						Type "Primary"
-						IfHealthBelow 13556
-					}
-					VoiceCommand // throw rock
-					{
-						Delay 12.5
-						Cooldown 20
-						Repeats 0
-						Type "Nice Shot"
 						IfHealthBelow 13556
 					}
 					WeaponSwitch
@@ -11741,6 +11694,11 @@ WaveSchedule
 				TFBot
 				{
 					Template T_Zombie_Special_Hulk
+					ItemAttributes
+					{
+						ItemName TF_WEAPON_SHOTGUN_HWG
+						"custom weapon fire sound" =100|shadows/tank_throw_01.mp3
+					}
 					Health 18863
 					Taunt
 					{
@@ -11790,14 +11748,6 @@ WaveSchedule
 						Type "Primary"
 						IfHealthBelow 16403
 					}
-					VoiceCommand // throw rock
-					{
-						Delay 12.5
-						Cooldown 20
-						Repeats 0
-						Type "Nice Shot"
-						IfHealthBelow 16403
-					}
 					WeaponSwitch
 					{
 						Delay 13.5
@@ -11818,6 +11768,11 @@ WaveSchedule
 				TFBot
 				{
 					Template T_Zombie_Special_Hulk
+					ItemAttributes
+					{
+						ItemName TF_WEAPON_SHOTGUN_HWG
+						"custom weapon fire sound" =100|shadows/tank_throw_02.mp3
+					}
 					Health 18863
 					DeathSound shadows\tank_death_02.mp3
 					Taunt
@@ -11868,14 +11823,6 @@ WaveSchedule
 						Type "Primary"
 						IfHealthBelow 16403
 					}
-					VoiceCommand // throw rock
-					{
-						Delay 12.5
-						Cooldown 20
-						Repeats 0
-						Type "Nice Shot"
-						IfHealthBelow 16403
-					}
 					WeaponSwitch
 					{
 						Delay 13.5
@@ -11896,6 +11843,11 @@ WaveSchedule
 				TFBot
 				{
 					Template T_Zombie_Special_Hulk
+					ItemAttributes
+					{
+						ItemName TF_WEAPON_SHOTGUN_HWG
+						"custom weapon fire sound" =100|shadows/tank_throw_03.mp3
+					}
 					Health 18863
 					DeathSound shadows\tank_death_03.mp3
 					Taunt
@@ -11944,14 +11896,6 @@ WaveSchedule
 						Cooldown 20
 						Repeats 0
 						Type "Primary"
-						IfHealthBelow 16403
-					}
-					VoiceCommand // throw rock
-					{
-						Delay 12.5
-						Cooldown 20
-						Repeats 0
-						Type "Nice Shot"
 						IfHealthBelow 16403
 					}
 					WeaponSwitch
@@ -12186,6 +12130,11 @@ WaveSchedule
 				TFBot
 				{
 					Template T_Zombie_Special_Hulk
+					ItemAttributes
+					{
+						ItemName TF_WEAPON_SHOTGUN_HWG
+						"custom weapon fire sound" =100|shadows/tank_throw_01.mp3
+					}
 					Health 20750
 					Taunt
 					{
@@ -12235,14 +12184,6 @@ WaveSchedule
 						Type "Primary"
 						IfHealthBelow 18043
 					}
-					VoiceCommand // throw rock
-					{
-						Delay 12.5
-						Cooldown 20
-						Repeats 0
-						Type "Nice Shot"
-						IfHealthBelow 18043
-					}
 					WeaponSwitch
 					{
 						Delay 13.5
@@ -12263,6 +12204,11 @@ WaveSchedule
 				TFBot
 				{
 					Template T_Zombie_Special_Hulk
+					ItemAttributes
+					{
+						ItemName TF_WEAPON_SHOTGUN_HWG
+						"custom weapon fire sound" =100|shadows/tank_throw_02.mp3
+					}
 					Health 20750
 					DeathSound shadows\tank_death_02.mp3
 					Taunt
@@ -12313,14 +12259,6 @@ WaveSchedule
 						Type "Primary"
 						IfHealthBelow 18043
 					}
-					VoiceCommand // throw rock
-					{
-						Delay 12.5
-						Cooldown 20
-						Repeats 0
-						Type "Nice Shot"
-						IfHealthBelow 18043
-					}
 					WeaponSwitch
 					{
 						Delay 13.5
@@ -12341,6 +12279,11 @@ WaveSchedule
 				TFBot
 				{
 					Template T_Zombie_Special_Hulk
+					ItemAttributes
+					{
+						ItemName TF_WEAPON_SHOTGUN_HWG
+						"custom weapon fire sound" =100|shadows/tank_throw_03.mp3
+					}
 					Health 20750
 					DeathSound shadows\tank_death_03.mp3
 					Taunt
@@ -12389,14 +12332,6 @@ WaveSchedule
 						Cooldown 20
 						Repeats 0
 						Type "Primary"
-						IfHealthBelow 18043
-					}
-					VoiceCommand // throw rock
-					{
-						Delay 12.5
-						Cooldown 20
-						Repeats 0
-						Type "Nice Shot"
 						IfHealthBelow 18043
 					}
 					WeaponSwitch
@@ -12448,7 +12383,8 @@ WaveSchedule
 						CharacterAttributes
 						{
 							"move speed bonus" 0.08
-							"is suicide counter" 5000
+							"is suicide counter" 2000
+							"force distribute currency on death" 1
 						}
 						Health 10000
 					}


### PR DESCRIPTION
Sntr — 18/01/2024 17:06
"so after a while I figure it's finally time to push the qol update to live, with files here for good measure while I try figuring out what a pull request is and how it works"
\+ shadows.lua
\+ mvm_shadows_b3_adv_bauernhof.pop
\+ mvm_shadows_scarynav.nav
```
- Non-Medic classes now have a passive health regeneration
- Adjusted Tank VO so some only play when they have no target in sight
- Adjusted damage numbers across all weapons
- Adjusted Tank's VO for throwing rocks
- Adjusted Tank's rock throwing to actually visually display the rock they are throwing
- Adjusted Tank projectile speed so people stop being hit by invisible rocks
- Adjusted the ending cinematic duration
- Increased +50% dmg bonus to +100% to account for damage value changes
- Added a check that disables bot spawning when gameover is called
- Added an Überweapon upgrade for the Beam Rifle
- Added an Überweapon upgrade for the Tactigatling
- Added an extra attribute for Double Tap purchases so Dragon's Fury also receives the perk bonus
- Updated custom navmesh (thanks, Whurr!)
- Re-added reanimators, non-Medic classes can now revive dead teammates and get a whopping $50
- Re-added a VO check that happens when a player kills a Tank
-- Originally removed due to its PT-implementation causing server crashes
- Removed various unused naff
- Made the DNA Rejuvenator a box-only melee weapon
- Fixed a case where DNA rejuvenator could reanimate special enemies
- Fixed a case where Ostarion's Reserve would refuse a purchase from thirsty patrons
- Fixed a case where Ostarion's effect would fail to function
- Fixed a case where rolling the potato makes the dumpster go away if rolled after a Fire Sale
- Fixed a longstanding godspot next to the grain silo
- Removed the Minigun's movement penalty because it only works on Heavy (Pyro can also equip it)
- Removed ammo adjustment workarounds that are no longer needed
-- Classes used to not inherit the ammo stats of the weapon they picked up and used their internal stats instead
-- This lead to shotgun classes like Soldier/Heavy having drastically less ammo when using non-shotgun secondaries
-- This has now been fixed so rafmod checks the weapon to see how much ammo it should hold
- Double Tap now grants a fire rate bonus for the Dragon's Fury as well
- Removed Engineer's secondary ammo penalty due to it 'bleeding over' to other weapons on that slot
```
