### PR TITLE
Update mtp.cfg

### DIFF
--- a/cfg/mtp.cfg
+++ b/cfg/mtp.cfg
@@ -18,6 +18,5 @@
 	"mvm_mannworks.bsp"			"1"
 	"mvm_rottenburg.bsp"		"1"
 	"mvm_mannhattan.bsp"			"1"
-	"mvm_bigrock.bsp"			"1"
 	"mvm_kelly_rc1b.bsp"		"1"
 }

--- a/cfg/mtp.cfg
+++ b/cfg/mtp.cfg
@@ -14,10 +14,10 @@
 	"mvm_bigrock.bsp"	"1"
 	"mvm_decoy.bsp"		"1"
 	"mvm_coaltown.bsp"	"1"
-	"mvm_coaltown_event.bsp"	"1"
+	"mvm_ghost_town.bsp"	"1"
 	"mvm_mannworks.bsp"			"1"
 	"mvm_rottenburg.bsp"		"1"
-	"mvm_manhattan.bsp"			"1"
+	"mvm_mannhattan.bsp"			"1"
 	"mvm_bigrock.bsp"			"1"
 	"mvm_kelly_rc1b.bsp"		"1"
 }


### PR DESCRIPTION
Changed wrong map name `mvm_coaltown_event` to `mvm_ghost_town` and fixed misspelling of mannhattan and removed duplicate `mvm_bigrock`