### PR TITLE
Add map fixes for Decompose, Hanami, Giza, Watermine

### DIFF
--- a/scripts/population/mvm_decompose_rc6b_adv_ghoulish_genesis.pop
+++ b/scripts/population/mvm_decompose_rc6b_adv_ghoulish_genesis.pop
@@ -37,36 +37,6 @@ population
                     		"OnTrigger" "pop_interface,UnPauseBotSpawning,,45,1"
                 	}
            	}
-        	Unstuck_System //teleport bots stuck in the wrong spawn door
-        	{
-            		NoFixup 1
-            		trigger_teleport //door a tele
-            		{
-                		"targetname" "door_a_stuck_tele"
-                		"mins" "-808 -344 -295"
-                		"maxs" "808 344 295"
-                		"origin" "-3336 -3416 295"
-                		"spawnflags" "1"
-                		"target" "door_a_stuck_target"
-            		}
-            		info_teleport_destination //door a tele dest
-            		{
-                		"targetname" "door_a_stuck_target"
-                		"origin" "164 -3048 247"
-            		}
-            		OnSpawnOutput
-            		{
-                		Target wave_reset_relay
-                		Action AddOutput
-                		Param "OnTrigger door_a_stuck_tele:Enable::0:-1"
-            		}
-            		OnSpawnOutput
-            		{
-                		Target gate01_relay
-                		Action AddOutput
-                		Param "OnTrigger door_a_stuck_tele:Disable::0:-1"
-            		}
-        	}
 			Countdown_Reminder
             {
                 NoFixup 1
@@ -120,7 +90,6 @@ population
         	Name "intel2"
         	ResetTime 6000
     	}
-    	SpawnTemplate "Unstuck_System"
     	SpawnTemplate "Countdown_Reminder"
 	SpawnTemplate "pottybreak"
 	Mission

--- a/scripts/population/mvm_giza_b7_adv_tomb_adventure.pop
+++ b/scripts/population/mvm_giza_b7_adv_tomb_adventure.pop
@@ -17,29 +17,8 @@ WaveSchedule
 	RespecLimit 2 //How many times the player can use refunds
 	PrecacheModel "models/bots/sniper_boss/bot_sniper_boss.mdl" [$SIGSEGV]
 	
-	PointTemplates [$SIGSEGV]
-    {
-        OutOfMapClip
-        {
-            func_forcefield
-            {
-                "disablereceiveshadows" "0"
-                "renderamt" "255"
-                "rendercolor" "255 255 255"
-                "renderfx" "0"
-                "rendermode" "10"
-                "TeamNum" "1"
-
-                "origin" "-1024 -1980 2016"
-                "mins" "-256 -68 -1056"
-                "maxs" "256 68 1056"    
-            }    
-        }
-    }
-	
 	Templates
 	{
-		
 		T_TFBot_Demo_Burst_FIX 
 		{
 			Class Demoman
@@ -2251,8 +2230,6 @@ WaveSchedule
 			Skill Expert
 		}
 	}
-	
-	SpawnTemplate "OutOfMapClip" [$SIGSEGV]
 	
 	Wave
 	{

--- a/scripts/vscripts/mapspawn.nut
+++ b/scripts/vscripts/mapspawn.nut
@@ -9,7 +9,22 @@
     IsSigmod = Convars.GetInt("sig_color_console") != null ? true : false
     //  Length of the current map name.
     len_mapname = GetMapName().len()
+
+    // Preserved entity handles; we only need to grab them once.
+    gamerules = null    // tf_gamerules
+    objres = null   // tf_objective_resource
+    plyrmgr = null  // tf_player_manager
+
+    // mapspawn.nut executes too early to grab entities immediately.
+    function PopulatePreservedEnts() {
+        gamerules = Entities.FindByClassname(null, "tf_gamerules")
+        objres = Entities.FindByClassname(null, "tf_objective_resource")
+        plyrmgr = Entities.FindByClassname(null, "tf_player_manager")
+        plyrmgr.ValidateScriptScope()
+    }
 }
+
+EntFire("worldspawn", "RunScriptCode", "__potato.PopulatePreservedEnts()")
 
 IncludeScript("potato/mapfixes.nut")    // Fixes for the base versions of some maps on Potato.
 IncludeScript("potato/nameformatter.nut")   // Automatically formats the mission display name.

--- a/scripts/vscripts/potato/hiderespawntext.nut
+++ b/scripts/vscripts/potato/hiderespawntext.nut
@@ -4,9 +4,6 @@ __potato.HideRespawnText <- {
     // Set to 1.0 to always show "Prepare to respawn" instead.
     texttype = 0.0
 
-    plyrmgr = null  // tf_player_manager handle
-    gamerules = null    // tf_gamerules handle
-
     // Check if we should hide text for this mission (RespawnWaveTime exceeds 1000s).
     function TestAndApply() {
         // Hack to guess if players are on RED or BLU
@@ -33,12 +30,6 @@ __potato.HideRespawnText <- {
     }
 
     Events = {
-        // Fired every mission change, wave jump or (post) wave fail.
-        function OnGameEvent_teamplay_round_start(_){
-            gamerules = Entities.FindByClassname(null, "tf_gamerules")
-            plyrmgr = Entities.FindByClassname(null, "tf_player_manager")
-            plyrmgr.ValidateScriptScope()
-        }
         // Fired every wave start.
         function OnGameEvent_mvm_begin_wave(_) {
             if (__potato.HideRespawnText.Disable) return

--- a/scripts/vscripts/potato/mapfixes.nut
+++ b/scripts/vscripts/potato/mapfixes.nut
@@ -64,6 +64,7 @@ __potato.MapFixes.Events <- {
             })
             forcefield.SetSize(Vector(-256, -68, -1056), Vector(256, 68, 1056))
             forcefield.SetSolid(Constants.ESolidType.SOLID_BBOX)
+            break
 
         // Lotus B6, Mansion RC1D, Watermine RC11
         // - Fixes the respawn room visualizers rendering behind props that are behind them.

--- a/scripts/vscripts/potato/mapfixes.nut
+++ b/scripts/vscripts/potato/mapfixes.nut
@@ -21,16 +21,55 @@ __potato.MapFixes.Events <- {
             }
             break
 
-        // Lotus B6
-        // - Fixes the spawn holograms rendering behind props that are behind them.
-        case "mvm_lotus_b6":
+        // Decompose RC6B
+        // - Adds a trigger_teleport to fix bots getting stuck in the wrong spawn door.
+        // - Fixes the respawn room visualizers rendering behind props that are behind them.
+        // - Hides the front vis as it has a black alpha layer on first map load.
+        case "mvm_decompose_rc6b":
             for (local vis; vis = Entities.FindByClassname(vis, "func_respawnroomvisualizer");)
                 NetProps.SetPropInt(vis, "m_nRenderMode", Constants.ERenderMode.kRenderTransColor)
+            local frontvis = Entities.FindByClassnameNearest("func_respawnroomvisualizer", 
+                                Vector(172, -2506.02, 355.5), 10.0)
+            NetProps.SetPropInt(frontvis, "m_nRenderMode", Constants.ERenderMode.kRenderNone)
+
+            // Setup gate teleport entities.
+            SpawnEntityFromTable("info_teleport_destination", {
+                targetname = "unstuck_dest"
+                origin = Vector(164, -3048, 247)
+            })
+            local door_unstuck = SpawnEntityFromTable("trigger_teleport", {
+                targetname = "unstuck_trigger"
+                target = "unstuck_dest"
+                origin = Vector(-3336, -3416, 295)
+                spawnflags = 1  // Clients only
+            })
+            door_unstuck.SetSize(Vector(-808, -344, -295), Vector(808, 344, 295))
+            door_unstuck.SetSolid(Constants.ESolidType.SOLID_BBOX)
+
+            // Enable/disable based on gate capture status.
+            EntityOutputs.AddOutput(Entities.FindByName(null, "wave_reset_relay"),
+                "OnTrigger", "unstuck_trigger", "Enable", "", -1, -1)
+            EntityOutputs.AddOutput(Entities.FindByName(null, "gate01_relay"),
+                "OnTrigger", "unstuck_trigger", "Disable", "", -1, -1)
             break
 
-        // Mansion RC1D
-        // - Fixes the spawn holograms rendering behind props that are behind them.
+        // Giza B7
+        // - Fix an out-of-bounds access spot.
+        case "mvm_giza_b7":
+            local forcefield = SpawnEntityFromTable("func_forcefield", {
+                origin = Vector(-1024, -1980, 2016)
+                rendermode = Constants.ERenderMode.kRenderNone
+                TeamNum = Constants.ETFTeam.TEAM_SPECTATOR
+                model = "models/weapons/w_models/w_rocket.mdl"
+            })
+            forcefield.SetSize(Vector(-256, -68, -1056), Vector(256, 68, 1056))
+            forcefield.SetSolid(Constants.ESolidType.SOLID_BBOX)
+
+        // Lotus B6, Mansion RC1D, Watermine RC11
+        // - Fixes the respawn room visualizers rendering behind props that are behind them.
+        case "mvm_lotus_b6":
         case "mvm_mansion_rc1d":
+        case "mvm_watermine_rc11":
             for (local vis; vis = Entities.FindByClassname(vis, "func_respawnroomvisualizer");)
                 NetProps.SetPropInt(vis, "m_nRenderMode", Constants.ERenderMode.kRenderTransColor)
             break
@@ -88,12 +127,21 @@ __potato.MapFixes.Events <- {
             tankcollect.SetSolid(Constants.ESolidType.SOLID_BBOX)
             break
 
+        // Hanami RC1
+        // - Fixes the tank barricade turning invisible after breaking once.
+        // - Fixes client prediction errors on the tank barricade.
+        case "mvm_hanami_rc1":
+            local barricade = Entities.FindByName(null, "prop_barricade")
+            barricade.AddEFlags(Constants.FEntityEFlags.EFL_IN_SKYBOX)
+            barricade.SetSolidFlags(Constants.ESolidType.SOLID_NONE)
+            break
         // Rottenburg
         // - Fixes the tank barricade turning invisible after breaking once.
         // - Fixes client prediction errors on the tank barricade.
         case "mvm_rottenburg":
-            EntFire("Barricade", "SetParent", "Tank_Barricade_Particle")
-            EntFire("Barricade", "DisableCollision")
+            local barricade = Entities.FindByName(null, "Barricade")
+            barricade.AddEFlags(Constants.FEntityEFlags.EFL_IN_SKYBOX)
+            barricade.SetSolidFlags(Constants.ESolidType.SOLID_NONE)
             break
     }}
 }

--- a/scripts/vscripts/potato/nameformatter.nut
+++ b/scripts/vscripts/potato/nameformatter.nut
@@ -5,10 +5,7 @@ __potato.NameFormatter <- {
     WinPanelDelay = 1.0         // Until the mission complete screen is shown
     HumiliationTime = 5.0       // Length of humiliation period, hardcoded to 5s in MvM
 
-    // Entity handles
-    objres = null   // tf_objective_resource
-    popscript = null    // Sigmod $script_manager
-
+    popscript = null    // Sigmod $script_manager handle.
     CustomMissionName = null  // Stores the mission maker's custom mission name.
 
     // EntFire checks so we don't format at the wrong time.
@@ -157,8 +154,6 @@ __potato.NameFormatter <- {
         function OnGameEvent_teamplay_round_start(_) {
             InVictory = false
             InHumiliation = false
-
-            objres = Entities.FindByClassname(null, "tf_objective_resource")
 
             if (IsSigmod) {
                 // The mission itself will make this entity if it has any raflua features.


### PR DESCRIPTION
- Remove redundant acquisitions of preserved entity handles in teamplay_round_start.
- Removed point template map fixes from Ghoulish Genesis and Tomb Adventure.
- mapfixes.nut
    - Decompose
        - Added trigger_teleport Gate A fix from Ghoulish Genesis.
        - Fixed func_respawnroomvisualizer rendering.
     - Hanami
        - Added tank barricade fixes from Rottenburg (Rottenburg's original fix has been updated with this more robust version).
     - Giza
        - Added func_forcefield OOB fix from Tomb Adventure.
     - Watermine
         - Fixed func_respawnroomvisualizer rendering.