### PR TITLE
Remove basic name formatting

### DIFF
--- a/scripts/population/marathon_logic.pop
+++ b/scripts/population/marathon_logic.pop
@@ -164,21 +164,6 @@ env_fade
 
 }
 
-MissionName
-{
-logic_relay
-{
-"targetname" "name"
-"OnTrigger" "tf_objective_resource,$SetClientProp$m_iszMvMPopfileName,Marathon (Advanced),0,-1"
-}
-OnSpawnOutput
-{
-Target "name"
-Action "trigger"
-Delay 0
-}
-}
-
 BossDeath
 {
 KeepAlive 1

--- a/scripts/population/mvm_bronx_rc2_adv_point_of_impact.pop
+++ b/scripts/population/mvm_bronx_rc2_adv_point_of_impact.pop
@@ -59,17 +59,6 @@ WaveSchedule
 			}
 		}
 
-        missionname1
-		{  
-			logic_auto 
-			{
-				"origin" "0 0 0" 
-				"targetname" "missionname"
-				
-				"OnMapSpawn" "tf_objective_resource,$SetClientProp$m_iszMvMPopfileName,Point Of Impact (Advanced),0,-1"
-			}
-		}
-
         real_squad_leader 
         {
             //OnSpawnOutput
@@ -105,8 +94,6 @@ WaveSchedule
             }
         }
 	}
-
-    SpawnTemplate "missionname1"
 
     //ExtraTankPath
     //{

--- a/scripts/population/mvm_cyberia_rc6a_exp_cascading_steel_swarm.pop
+++ b/scripts/population/mvm_cyberia_rc6a_exp_cascading_steel_swarm.pop
@@ -242,20 +242,6 @@ population
 	}
 	PointTemplates
 	{
-	the_part_where
-		{ 
-			logic_relay
-			{
-				"targetname" "istoleyourlogic"
-				"origin" "0 0 0"
-				"OnTrigger" "tf_objective_resource,$SetClientProp$m_iszMvMPopfileName,EXP Cascading Steel Swarm,0,-1"
-			}
-			OnSpawnOutput
-			{
-				Target "istoleyourlogic" 
-				Action trigger
-			}
-		}
 	nuke
         {
             prop_dynamic
@@ -622,7 +608,6 @@ population
 			}
 				}
 	}
-	SpawnTemplate "the_part_where"
 	Wave
 	{
 		Checkpoint	Yes

--- a/scripts/population/mvm_doppler_b12_exp_object_oriented_obliteration.pop
+++ b/scripts/population/mvm_doppler_b12_exp_object_oriented_obliteration.pop
@@ -36,20 +36,6 @@ population
 	
 	PointTemplates   
 	{
-	the_part_where
-		{ 
-			logic_relay
-			{
-				"targetname" "istoleyourlogic"
-				"origin" "0 0 0"
-				"OnTrigger" "tf_objective_resource,$SetClientProp$m_iszMvMPopfileName,EXP Object Oriented Obliteration,0,-1"
-			}
-			OnSpawnOutput
-			{
-				Target "istoleyourlogic" 
-				Action trigger
-			}
-		}
 		FixedSpawns //thanksselpit
 {
     logic_relay
@@ -1412,7 +1398,6 @@ Attributes AlwaysCrit
 	}
 	}
 	
-	SpawnTemplate "the_part_where"
 	SpawnTemplate StunProtectBomb
 	SpawnTemplate "FixedSpawns"
 	

--- a/scripts/population/mvm_humbridge_b10_adv_hampton_helix.pop
+++ b/scripts/population/mvm_humbridge_b10_adv_hampton_helix.pop
@@ -32,7 +32,6 @@ WaveSchedule
 				"origin" "0 0 0" 
 				"targetname" "mainrelay"
 				
-				"OnMapSpawn" "tf_objective_resource,$SetClientProp$m_iszMvMPopfileName,Hampton Helix,0,-1"
 				"OnMapSpawn" "cap_destroy_relay,AddOutput,OnTrigger tankboss:DestroyIfAtCapturePoint:1:-1"
 				"OnMapSpawn" "boss_deploy_relay,AddOutput,OnTrigger tankboss:DestroyIfAtCapturePoint:0:-1"
 			}

--- a/scripts/population/mvm_humbridge_b10_exp_misanthrope.pop
+++ b/scripts/population/mvm_humbridge_b10_exp_misanthrope.pop
@@ -397,13 +397,6 @@ whatever_this_popfile_is
             //    Delay 0.01
             //}
             // Sike fake icon
-            OnSpawnOutput
-            {
-                Target tf_objective_resource
-                Action $SetClientProp$m_iszMvMPopfileName
-                Param "Misanthrope (Expert)"
-                Delay 0.01
-            }
             logic_relay
             {
                 "targetname" "not_alive"

--- a/scripts/population/mvm_jungleworks_rc1_adv_euterpeprecatoriaffray.pop
+++ b/scripts/population/mvm_jungleworks_rc1_adv_euterpeprecatoriaffray.pop
@@ -78,20 +78,6 @@ WaveSchedule
             "origin" "-136 2080 584"
         }
     }
-	the_part_where
-		{ 
-			logic_relay
-			{
-				"targetname" "istoleyourlogic"
-				"origin" "0 0 0"
-				"OnTrigger" "tf_objective_resource,$SetClientProp$m_iszMvMPopfileName,ADV Euterpeprecatoriaffray,0,-1"
-			}
-			OnSpawnOutput
-			{
-				Target "istoleyourlogic" 
-				Action trigger
-			}
-		}
 		
 		Dispenser
 		{
@@ -447,7 +433,6 @@ WaveSchedule
 	}
 	
 	
-	Spawntemplate "the_part_where"
 	SpawnTemplate "antistuck"
 	
 	Wave

--- a/scripts/population/mvm_legerdemain_a6e_rev_adv_castle_crush.pop
+++ b/scripts/population/mvm_legerdemain_a6e_rev_adv_castle_crush.pop
@@ -1551,7 +1551,6 @@ WaveSchedule
 				"origin" "0 0 0" 
 				"targetname" "mainrelay"
 				
-				"OnMapSpawn" "tf_objective_resource,$SetClientProp$m_iszMvMPopfileName,Castle Crush (Advanced),0,-1"
 				"OnMapSpawn" "item_ammopack*,Kill,,0,-1" 				//don't need these, you got inf ammo
 				"OnMapSpawn" "filter_gatebot*,Kill,,0,-1" 				// piss off and lemme cap
 				"OnMapSpawn" "upgradestationfront_station,Kill,,0,-1" 

--- a/scripts/population/mvm_lotus_b6_adv_ledmotif.pop
+++ b/scripts/population/mvm_lotus_b6_adv_ledmotif.pop
@@ -31,7 +31,6 @@ WaveSchedule
 				"origin" "0 0 0" 
 				"targetname" "mainrelay"
 				
-				"OnMapSpawn" "tf_objective_resource,$SetClientProp$m_iszMvMPopfileName,LED-Motif (Advanced),0,-1"
 				"OnMapSpawn" "cap_destroy_relay,AddOutput,OnTrigger tankboss:DestroyIfAtCapturePoint:1:-1"
 				"OnMapSpawn" "boss_deploy_relay,AddOutput,OnTrigger tankboss:DestroyIfAtCapturePoint:0:-1"
 				"OnMapSpawn" "tank_path_air_1,AddOutput,OnPass hint_blimp:Show:0:-1"

--- a/scripts/population/mvm_madhattan_rc5a_exp_diamonds_in_the_rough.pop
+++ b/scripts/population/mvm_madhattan_rc5a_exp_diamonds_in_the_rough.pop
@@ -89,22 +89,6 @@ WaveSchedule
     //  }
 	//}
 
-    PointTemplates  
-	{
-		missionname1
-		{  
-			logic_auto 
-			{
-				"origin" "0 0 0" 
-				"targetname" "missionname"
-				
-				"OnMapSpawn" "tf_objective_resource,$SetClientProp$m_iszMvMPopfileName,Diamonds In The Rough,0,-1"
-			}
-		}
-    }
-
-    SpawnTemplate "missionname1"
-
     Mission
     {
         Objective DestroySentries

--- a/scripts/population/mvm_oilrig_rc5a_adv_waters_of_wrath.pop
+++ b/scripts/population/mvm_oilrig_rc5a_adv_waters_of_wrath.pop
@@ -43,7 +43,7 @@ this_is_most_certainly_a_popfile._quite_possibly_one_of_the_popfiles_ever_made
 			logic_relay
 			{
 				"targetname"	"ultrakrill"
-				"OnTrigger"		"tf_objective_resource,$SetClientProp$m_iszMvMPopfileName,Oilrig /// Waters of Wrath (VIOLENT),0,-1"
+				"OnTrigger"		"tf_objective_resource,$SetClientProp$m_iszMvMPopfileName,Waters of Wrath (VIOLENT),0,-1"
 			}
 			OnSpawnOutput
 			{

--- a/scripts/population/mvm_quetzal_rc5_exp_banana_barricade.pop
+++ b/scripts/population/mvm_quetzal_rc5_exp_banana_barricade.pop
@@ -155,20 +155,6 @@ population
 					"OnTimer" "alarm_sound,StopSound,,2,-1"
 				}
 			}
-			MissionName
-			{
-				logic_relay
-				{
-					"targetname" "name"
-					"OnTrigger" "tf_objective_resource,$SetClientProp$m_iszMvMPopfileName,Banana Barricade (Expert),0,-1"
-				}
-				OnSpawnOutput
-				{
-					Target "name"
-					Action "trigger"
-					Delay 0
-				}
-			}
 			NoReset_Improved // Fix made by Yuugi
 			{
 				func_forcefield
@@ -1306,7 +1292,6 @@ population
 		}
 	}
 	SpawnTemplate Arson
-	SpawnTemplate MissionName
 	Wave
 	{
 		WaitWhenDone	65

--- a/scripts/population/mvm_robotfactory_b28_exp_enduring_exceptions.pop
+++ b/scripts/population/mvm_robotfactory_b28_exp_enduring_exceptions.pop
@@ -1326,20 +1326,6 @@ WaveSchedule
 				Delay 0.01
 			}
 		}
-	nameChange
-		{ 
-			logic_relay
-			{
-				"targetname" "nameChange"
-				"origin" "0 0 0"
-				"OnTrigger" "tf_objective_resource,$SetClientProp$m_iszMvMPopfileName,EXP Enduring Exceptions,0,-1"
-			}
-			OnSpawnOutput
-			{
-				Target "nameChange" 
-				Action trigger
-			}			
-		}
 		nukeSoldierFunni
 		{
 				logic_relay
@@ -1696,7 +1682,6 @@ WaveSchedule
 	
 	//Leaving these templates laying around is harmless because they are only invoked when they are needed.
 	//Unlike say, a template that lays a bunch of props around the place.
-	SpawnTemplate "nameChange"
 	SpawnTemplate "nukeSoldierFunni"
 	SpawnTemplate "music_3"
 	Mission

--- a/scripts/population/mvm_robotfactory_b28_rev_adv_short_circuit_execution.pop
+++ b/scripts/population/mvm_robotfactory_b28_rev_adv_short_circuit_execution.pop
@@ -1936,20 +1936,6 @@ WaveSchedule
 	
 	PointTemplates
 {
-	nameChange
-		{ 
-			logic_relay
-			{
-				"targetname" "nameChange"
-				"origin" "0 0 0"
-				"OnTrigger" "tf_objective_resource,$SetClientProp$m_iszMvMPopfileName,ADV Short Circuit Execution,0,-1"
-			}
-			OnSpawnOutput
-			{
-				Target "nameChange" 
-				Action trigger
-			}
-		}	
 	LoseRelay 
 	{
 		NoFixup 1
@@ -7102,7 +7088,6 @@ WaveSchedule
 			SpawnTemplate LaserOnAim
 		}
 	}
-	SpawnTemplate "nameChange"
 	
 
 	// WAVE 1 [$0]

--- a/scripts/population/mvm_rottenburg_adv_marathon.pop
+++ b/scripts/population/mvm_rottenburg_adv_marathon.pop
@@ -35,7 +35,6 @@ UpgradeStationKeepWeapons	1
 
 PrecacheModel "models/weapons/c_models/c_firelauncher/c_firelauncher.mdl"
 
-SpawnTemplate "MissionName"
 SpawnTemplate "Moosic"
 SpawnTemplate "barriers"
 SpawnTemplate "vendors"

--- a/scripts/population/mvm_rottenburg_exp_germanium_gearbox.pop
+++ b/scripts/population/mvm_rottenburg_exp_germanium_gearbox.pop
@@ -26,27 +26,9 @@ population
 	CanBotsAttackWhileInSpawnRoom	no
 	AddSentryBusterWhenDamageDealtExceeds	2500
 	Advanced	1
-	
-	//	Im not sure how it works, but apparently this part changes the popfile name in the tab menu to 'EXP Germanium Gearbox'.
-	//	Copied (with slight modifications) from Humbridge - Hampton Helix. Rafmod magic right there, hopefully it wont break anything.
-	//	Disabled due to it breaking the popfile in the offline server :( . This will be reactivated once shipped to Potato.
-	
-	//PointTemplates   
-	//{
-	//	corelogic
-	//	{  
-	//		logic_auto 
-	//		{
-	//			"origin" "0 0 0" 
-	//			"targetname" "mainrelay"
-	//			"OnMapSpawn" "tf_objective_resource,$SetClientProp$m_iszMvMPopfileName,EXP Germanium Gearbox,0,-1"
-	//		}
-	//	}
-	//}		
-	//SpawnTemplate "corelogic"
+
 	PrecacheSound "soldiermc.mp3" [$SIGSEGV]	//	precaching the sound file in wave 5 so all players will be forced to download it.
-	
-	
+
 	Mission
 	{
 		Objective	DestroySentries

--- a/scripts/population/mvm_saxford_rc1_adv_streetway_sections.pop
+++ b/scripts/population/mvm_saxford_rc1_adv_streetway_sections.pop
@@ -62,23 +62,8 @@ Stupid
 		Z	"-108.968681"
 		StartDisabled 1
 	}
-	SpawnTemplate MissionName
 	PointTemplates
 	{
-		MissionName
-		{
-			logic_relay
-			{
-				"targetname" "name"
-				"OnTrigger" "tf_objective_resource,$SetClientProp$m_iszMvMPopfileName,Streetway Sections (Advanced),0,-1"
-			}
-			OnSpawnOutput
-			{
-				Target "name"
-				Action "trigger"
-				Delay 0
-			}
-		}
         	SmallTankTurret
 		{
             		OnSpawnOutput

--- a/scripts/population/mvm_skeleclipse_b7a_exp_when_the_sun_shines_red.pop
+++ b/scripts/population/mvm_skeleclipse_b7a_exp_when_the_sun_shines_red.pop
@@ -41,7 +41,6 @@ population
 			NoFixup 1
             logic_auto
             {
-                //"OnMapSpawn" "tf_objective_resource,$SetClientProp$m_iszMvMPopfileName,When the Sun Shines Red,0,-1"
                 "OnMapSpawn" "player,Color,255 255 255,0,-1"
                 "OnMapSpawn" "demobosstargetname,AddOutput,targetname yes,1,-1"
                 //"OnMapSpawn" "individualfiremaker,AddOutput,OnUser1 individualfiremaker:ForceSpawnAtEntityOrigin:spawnbot:0:-1,0,-1"

--- a/scripts/population/mvm_spybase_rc8_exp_waters_of_a_robot_regime.pop
+++ b/scripts/population/mvm_spybase_rc8_exp_waters_of_a_robot_regime.pop
@@ -1189,20 +1189,6 @@ TremendoPinoHePlantado
 					"OnTrigger"	"CarrierLaunch_cloak,kill,,12,-1"
 				}
 			}
-		MissionName
-		{
-			logic_relay
-			{
-				"targetname" "name"
-				"OnTrigger" "tf_objective_resource,$SetClientProp$m_iszMvMPopfileName,EXP Waters of a robot regime,0,-1"
-			}
-			OnSpawnOutput
-			{
-				Target "name"
-				Action "trigger"
-				Delay 0
-			}
-		}
 		
 			scrapped_spawns
 			{
@@ -2419,7 +2405,6 @@ TremendoPinoHePlantado
 	SpawnTemplate resetbossstatues
 	SpawnTemplate w6intro
 	SpawnTemplate CarrierLaunch_cloak
-    SpawnTemplate MissionName
 	SpawnTemplate scrapped_spawns
 	SpawnTemplate Foreshadowing
 	SpawnTemplate bombthesub

--- a/scripts/population/mvm_steep_rc3a_adv_claire_de_laube.pop
+++ b/scripts/population/mvm_steep_rc3a_adv_claire_de_laube.pop
@@ -226,7 +226,7 @@ population
 			{
 				"targetname" "istoleyourlogic"
 				"origin" "0 0 0"
-				"OnTrigger" "tf_objective_resource,$SetClientProp$m_iszMvMPopfileName,ADV Claire De L'aube,0,-1"
+				"OnTrigger" "tf_objective_resource,$SetClientProp$m_iszMvMPopfileName,(ADV) Claire De L'aube,0,-1"
 			}
 			OnSpawnOutput
 			{

--- a/scripts/population/mvm_steep_rc3a_adv_drill_down_disaster.pop
+++ b/scripts/population/mvm_steep_rc3a_adv_drill_down_disaster.pop
@@ -369,20 +369,6 @@ IShatMyself
 			}
 			
 		}
-		MissionName
-		{
-			logic_relay
-			{
-				"targetname" "name"
-				"OnTrigger" "tf_objective_resource,$SetClientProp$m_iszMvMPopfileName,Drill Down Disaster (Advanced),0,-1"
-			}
-			OnSpawnOutput
-			{
-				Target "name"
-				Action "trigger"
-				Delay 0
-			}
-		}
 		music
 		{
 			ambient_generic
@@ -1916,7 +1902,6 @@ IShatMyself
 		}
 	}
 	SpawnTemplate No_pyro_stuck
-	SpawnTemplate MissionName
 	SpawnTemplate Live
     SpawnTemplate CarrierLaunch
 	SpawnTemplate CarrierLaunch_cloak


### PR DESCRIPTION
Removes a lot of the changes made to "m_iszMvMPopfileName" prop by individual missions in favour of using the Potato standard formatting, a backport effort from the [changes made in OO](https://i.imgur.com/9WAz7en.png).

<p> </p>
I've left missions alone that do this for flavour reasons (such as "Bauernhof Der Toten"). The exceptions to this rule include:

- Waters of Wrath
   - "Oilrig /// Waters of Wrath (VIOLENT)" -> "Waters of Wrath (VIOLENT)"
   - Anything before forward slashes in the mission name are removed by the game anyway, as a file path is expected here.
- Claire De L'aube
    - "ADV Claire De L'aube" -> "(ADV) Claire De L'aube"
    - This name formatting simply adds the apostrophe missing from the file name, so I just made it consistent with the name formatter manually.
        - This issue also applies to Death's Door; should the file names for these two missions ever be updated, I'd also like to throw in "Autonomous Annilhilation" [sic] as a candidate to be renamed, alongside RR Bigrock missions (missing mission difficulties).