### PR TITLE
(minor) Update mvm_deathpour_rc1_exp_blackout.pop

### DIFF
--- a/scripts/population/mvm_deathpour_rc1_exp_blackout.pop
+++ b/scripts/population/mvm_deathpour_rc1_exp_blackout.pop
@@ -110,6 +110,10 @@
 //w5:
 //regen gmeds into popping gmeds.
 
+//11/08/2024 (DDMMYYYY)
+//Replaced stock icons for popper gmed and airblasting gpyro with custom variants (already included in archive assets).
+//Also gave the gpyro the cosmetic set for airblasting and the name.
+
 #base robot_standard.pop
 #base robot_giant.pop
 
@@ -1647,6 +1651,10 @@ WaveSchedule
 				TFBot
 				{
 					Template T_TFBot_Giant_Pyro
+					ClassIcon pyro_reflect_daan
+					Item "Traffic Cone"
+					Item "The Degreaser"
+					Name "Giant Airblast Pyro"
 					Attributes AlwaysCrit
 				}
 		}
@@ -2023,6 +2031,7 @@ WaveSchedule
 				TFBot
 				{
 					Template T_TFBot_Giant_Medic //_Regen
+					ClassIcon medic_pop
 				}
 			}
 		}


### PR DESCRIPTION
Tweaked icons for certain bots (with icons already in asset pack) For:
Giant Pyro (airblasting)
^ Also recieved some cosmetic changes.
Giant Medic (popping)