### PR TITLE
Fix mvm_decompose_rc6b_adv_ghoulish_genesis.pop

### DIFF
--- a/scripts/population/mvm_decompose_rc6b_adv_ghoulish_genesis.pop
+++ b/scripts/population/mvm_decompose_rc6b_adv_ghoulish_genesis.pop
@@ -2266,7 +2266,7 @@ population
                         Support 1
 			TFBot
 			{
-                        ClassIcon pyro
+                        ClassIcon pyro_giant
                         	Name "Deflector Pyro"
 				Class Pyro
                         	Skill Hard


### PR DESCRIPTION
Icon stacking (mainwave w support) fixed by setting support's icon from "pyro" to "pyro_giant" (there is no other usage of pyro_giant in the mission)