### PR TITLE
Fix mvm_coastrock_rc2_adv_coastal_calamity.pop

### DIFF
--- a/scripts/population/mvm_coastrock_rc2_adv_coastal_calamity.pop
+++ b/scripts/population/mvm_coastrock_rc2_adv_coastal_calamity.pop
@@ -827,6 +827,7 @@ WaveSchedule
 						"airblast vulnerability multiplier" 0.01
 						"airblast vertical vulnerability multiplier" 0.01
 					}
+					ClassIcon demo_burst_giant
 				}
 				TFBot
 				{
@@ -1179,6 +1180,7 @@ WaveSchedule
 						"airblast vulnerability multiplier" 0.01
 						"airblast vertical vulnerability multiplier" 0.01
 					}
+					ClassIcon demo_clusterbomb_giant
 				}
 				TFBot
 				{


### PR DESCRIPTION
w2 burst demo icons unstacked using vmts already in the asset pack