### PR TITLE
Calendartillery: Tags updated to match popext

### DIFF
--- a/scripts/population/mvm_rottenburg_int_calendartillery.pop
+++ b/scripts/population/mvm_rottenburg_int_calendartillery.pop
@@ -166,7 +166,7 @@ WaveSchedule
 			Item "Wipe Out Wraps"
 			Item "Blizzard Britches"
 			Item "Snowwing"
-			Tag "popext_stripslot|2|2"
+			Tag "popext_stripslot{slot = 2}"
 			ItemAttributes
 			{
 				ItemName "Mad Milk"
@@ -194,7 +194,7 @@ WaveSchedule
 			Item "Wipe Out Wraps"
 			Item "Blizzard Britches"
 			Item "Snowwing"
-			Tag "popext_stripslot|0|0"
+			Tag "popext_stripslot{slot = 0}"
 			ItemAttributes
 			{
 				ItemName "Mad Milk"
@@ -707,8 +707,7 @@ WaveSchedule
 			ClassIcon heavy_fist_nys //temp; final may be demo_fast //we might need a more suitable icon for this
 			Name "Creature of the Night"
 			Skill Hard
-			// Tag "popext_giveweapon|tf_weapon_fists|5" //Fists
-			Tag "popext_customweaponmodel|models/empty.mdl"
+			Tag "popext_customweaponmodel{ model = `models/empty.mdl` }"
 			Tag "wolfhair"
 			Item "Hair of the Dog"
 			Item "Scottish Snarl"
@@ -760,7 +759,7 @@ WaveSchedule
 			Item "The Sole Saviors"
 
 			//Items
-			Tag "popext_stripslot|0|0" //Remove booties
+			Tag "popext_stripslot{ slot = 0 }" //Remove booties
 			Tag "fireball_knight"
 			//does this stripslot thing even work with only one argument???
 			Item "The Splendid Screen" //Chargin Targe gives too more beefyness
@@ -785,8 +784,7 @@ WaveSchedule
 				"dmg penalty vs players" 0.75
 				"Projectile speed increased" 0.7
 			}
-			Tag "popext_spell|0|5|3" // Gives specified spell to bots. 0 = Fireball|cooldown|delay
-			// Tag "popext_homingprojectile|15|0.7" / Very, very laggy. May not be worth it :<
+			Tag "popext_spell{ type = 0, cooldown = 5, delay = 3 }" // Gives specified spell to bots. 0 = Fireball.
 			CharacterAttributes
 			{
 				"move speed bonus" 0.5
@@ -909,7 +907,7 @@ WaveSchedule
 			Scale 1.4
 			Health 650
 			Skill Hard
-			Tag "popext_giveweapon|tf_weapon_fireaxe|474"
+			Tag "popext_giveweapon{ weapon = `tf_weapon_fireaxe`, id = 474 }"
 			Tag "learnerspermit"
 			Item "The Conscientious Objector"
             Item "Pyro the Flamedeer"
@@ -961,8 +959,6 @@ WaveSchedule
 			Item "Upgradeable TF_WEAPON_GRENADELAUNCHER" 
 			Attributes HoldFireUntilFullReload
 			Tag "milkdemo"
-			//Until someone fixes this
-			// Tag "popext_customattr|add cond on hit|[27,6]"
 			ItemAttributes
 			{
 				ItemName "Upgradeable TF_WEAPON_GRENADELAUNCHER"
@@ -1000,9 +996,9 @@ WaveSchedule
 			Item "The Sole Saviors"
 
 			//Items
-			Tag "popext_stripslot|0|0" //Remove booties
+			Tag "popext_stripslot{ slot = 0 }" //Remove booties
 			Tag "fireball_knight"
-			Tag "popext_spell|0|10|3"
+			Tag "popext_spell{ type = 0, cooldown = 10, delay = 3}"
 			Item "The Splendid Screen" //Chargin Targe gives too more beefyness
 			Item "The Eyelander"
 			Item "TF_WEAPON_SPELLBOOK"
@@ -1049,7 +1045,6 @@ WaveSchedule
 			Item "The Bone Cone"
 			Item "Creepy Crawlers"
 			Item "harvest_minigun_macabreweb"
-			// Tag "popext_customattr|custom projectile model|models/props_halloween/smlprop_spider.mdl"
 			MaxVisionRange 1200
 			ItemAttributes
 			{
@@ -1082,7 +1077,6 @@ WaveSchedule
 			Item "The Jarmaments"
 			WeaponRestrictions PrimaryOnly
 			Action FetchFlag [$SIGSEGV]
-			// Tag "popext_aimat|flag" //was AimAt Body; flag is approx at the same spot.
 			// AimOffset "0 0 10"  
 			// AimLeadProjectileSpeed 1100   //overaims slightly
 			ItemAttributes
@@ -1106,8 +1100,6 @@ WaveSchedule
 			Item "Sniper's Snipin' Glass"
 			Item "The Jarmaments"
 			Tag "Jarcher"
-			//Until someone fixes this
-			// Tag "popext_addcondonhit|24|4"
 			ItemAttributes
 			{
 				ItemName "The Huntsman"
@@ -1208,8 +1200,6 @@ WaveSchedule
 			// Item "Mad Lad"
 			Item "The Gas Guzzler"
 			Tag "neondemo"
-			// Tag "popext_customattr|projectile gravity|200"
-			// Tag "popext_aimat" / changed to Tag, was AimAt Head
 			ItemAttributes
 			{
 				ItemName "Upgradeable TF_WEAPON_GRENADELAUNCHER"
@@ -1284,7 +1274,6 @@ WaveSchedule
 			Skill Hard
 			Attributes MiniBoss
 			WeaponRestrictions SecondaryOnly
-			// Tag "popext_aimat|head"
 			Item "The Flare Gun"
 			Item "Brim of Fire"
 			Item "Propaniac"
@@ -1407,25 +1396,7 @@ WaveSchedule
 			Item "Preventative Measure"
 			Item "The Doublecross-Comm"
 			Item "The Triggerman's Tacticals"
-			Tag "popext_addcond|46"
-			// Tag "popext_stripslot" / changed to Tag
-			// AddCond 46  
-			// Tag "popext_weaponswitch" / changed to Tag, didn't modify below
-			// {
-				// Delay 1
-				// Cooldown 0.5
-				// Repeats 0
-				// Type "Primary"
-				// MinTargetRange 400
-			// }
-			// WeaponSwitch  
-			// {
-				// Delay 1
-				// Cooldown 2
-				// Repeats 0
-				// Type "Secondary"
-				// MaxTargetRange 250
-			// }
+			Tag "popext_addcond{ cond = 46 }"
 			ItemAttributes
 			{
 				ItemName "The Cleaner's Carbine"
@@ -1483,8 +1454,8 @@ WaveSchedule
 			Item "The Sangu Sleeves"
 			Item "The Scrumpy Strongbox"
 			Tag "popext_usehumananims" //Fixes animations when passive grenade launcher is not possible.
-			Tag "popext_weaponswitch|0|12|0.1"
-			Tag "popext_weaponswitch|1|12|3.6"
+			Tag "popext_weaponswitch{ slot = 0, cooldown = 12, delay = 0.1 }"
+			Tag "popext_weaponswitch{ slot = 1, cooldown = 12, delay = 3.6 }"
 			Tag "infclip"
 			ItemAttributes
 			{
@@ -1640,7 +1611,6 @@ WaveSchedule
             Item "Li'l Snaggletooth"
             Item "Rocko"
             Tag "popext_usehumanmodel"
-			// Tag "popext_fireweapon|"
 			CharacterAttributes
 			{
 				"mod weapon blocks healing" 1
@@ -1656,7 +1626,7 @@ WaveSchedule
             Item "The Most Dangerous Mane"
             Item "Rifleman's Regalia"
             Tag "popext_usehumanmodel"
-			Tag "popext_addcond|46"
+			Tag "popext_addcond{ cond = 46 }"
 			CharacterAttributes
 			{
 				"mod weapon blocks healing" 1


### PR DESCRIPTION
Updated all tags that use "pipe" syntax, with the | character, to now use tables within the tags. If possible, please ensure I did this right for the valid tags:
- spell
- stripslot
- giveweapon
- customweaponmodel
- addcond
- weaponswitch