### PR TITLE
Fix mvm_giza_b7_adv_666_wrath_of_the_pharaoh.pop

### DIFF
--- a/scripts/population/mvm_giza_b7_adv_666_wrath_of_the_pharaoh.pop
+++ b/scripts/population/mvm_giza_b7_adv_666_wrath_of_the_pharaoh.pop
@@ -3060,7 +3060,7 @@ population
 			{
 				TFBot
 				{
-					ClassIcon	scout
+					ClassIcon	scout_giant
 					Health	125
 					Name	"Crit Scout"
 					Class	Scout


### PR DESCRIPTION
Fixed icon issue on Wave 4 where support and mainwave scouts would stack, leading to a gap in the wavebar. 
Before:
https://media.discordapp.net/attachments/587862013779378186/1296057461744341053/image.png?ex=6710e712&is=670f9592&hm=6a50c1233590c9571bd918d83c6d90c282686cc5f56c6dae6dd9803fb1f92e1b&=&format=webp&quality=lossless&width=1100&height=136 
After:
https://media.discordapp.net/attachments/587862013779378186/1296057596901462036/image.png?ex=6710e732&is=670f95b2&hm=55d4d1a3b7faa571cebe2129a011bde5dc45b455308935e7abc50a4cb4498ca8&=&format=webp&quality=lossless&width=2160&height=262