### PR TITLE
Fix Grim Memorial

### DIFF
--- a/scripts/population/mvm_saxford_rc1_adv_grim_memorial.pop
+++ b/scripts/population/mvm_saxford_rc1_adv_grim_memorial.pop
@@ -604,8 +604,9 @@ WaveSchedule
             Param "
                 IncludeScript(`popextensions_main.nut`, getroottable())
                 IncludeScript(`mvm_saxford_rc1_adv_grim_memorial_templates.nut`)
+                IncludeScript(`mvm_saxford_rc1_adv_grim_memorial_tags.nut`)
                 SpawnTemplate(`Dipshit_Alarm`)
-                Info(`Some robots may spawn from behind, a teleport sound will be heard when this happens.`, `00FF26`, `INFO! `, false, 0, 0)
+                PopExtUtil.Info(`Some robots may spawn from behind, a teleport sound will be heard when this happens.`, `00FF26`, `INFO! `, false, 0, 0)
             "
         }
         DoneOutput
@@ -771,6 +772,7 @@ WaveSchedule
             Action RunScriptCode
             Param "
                 IncludeScript(`popextensions_main.nut`, getroottable())
+                IncludeScript(`mvm_saxford_rc1_adv_grim_memorial_tags.nut`)
             "
         }
         DoneOutput
@@ -1002,6 +1004,7 @@ WaveSchedule
             Action RunScriptCode
             Param "
                 IncludeScript(`popextensions_main.nut`, getroottable())
+                IncludeScript(`mvm_saxford_rc1_adv_grim_memorial_tags.nut`)
             "
         }
         DoneOutput
@@ -1304,6 +1307,7 @@ WaveSchedule
             Param "
                 IncludeScript(`popextensions_main.nut`, getroottable())
                 IncludeScript(`mvm_saxford_rc1_adv_grim_memorial_templates.nut`)
+                IncludeScript(`mvm_saxford_rc1_adv_grim_memorial_tags.nut`)
                 SpawnTemplate(`Dipshit_Alarm`)
                 PrecacheModel(`models/buildables/dispenser_lvl3_light.mdl`)
                 EntFire(`annotations_for_dipshits`, `kill`)
@@ -1704,6 +1708,7 @@ WaveSchedule
             Action RunScriptCode
             Param "
                 IncludeScript(`popextensions_main.nut`, getroottable())
+                IncludeScript(`mvm_saxford_rc1_adv_grim_memorial_tags.nut`)
             "
         }
         DoneOutput
@@ -2044,6 +2049,7 @@ WaveSchedule
             Param "
                 IncludeScript(`popextensions_main.nut`, getroottable())
                 IncludeScript(`mvm_saxford_rc1_adv_grim_memorial_templates.nut`)
+                IncludeScript(`mvm_saxford_rc1_adv_grim_memorial_tags.nut`)
                 SpawnTemplate(`Bringonthethunda`)
                 SpawnTemplate(`Grimmemorial_Stunner`)
             "

--- a/scripts/vscripts/mvm_saxford_rc1_adv_grim_memorial_tags.nut
+++ b/scripts/vscripts/mvm_saxford_rc1_adv_grim_memorial_tags.nut
@@ -1,31 +1,18 @@
-::__tagarray <-  [
-	"popext_forceromevision"
-	"popext_usehumananims"
-    "popext_spawntemplate"
-    "popext_spawntemplate|Dispensomat_boss"
-    "popext_spawntemplate|Grimmemorial_Boss"
-]
+// Logic for making every bot look like a Heavy bot.
+PopExt.AddRobotTag("bot_heavycommon", {
+	OnSpawn = function(bot, _) {
+		bot.SetCustomModelWithClassAnimations("models/player/" + PopExtUtil.Classes[bot.GetPlayerClass()] + ".mdl")
+		PopExtUtil.PlayerRobotModel(bot, "models/bots/heavy/bot_heavy.mdl")
+	},
+	OnDeath = function(bot, _)
+		bot.SetCustomModelWithClassAnimations("models/bots/heavy/bot_heavy.mdl")
+})
 
-// custom tags, code taken from popextensions+'s tags.nut
-
-    PopExt.AddRobotTag("bot_heavycommon", {
-        OnSpawn = function(bot, tag) {
-            local class_string = PopExtUtil.Classes[bot.GetPlayerClass()]
-           	EntFireByHandle(bot, "SetCustomModelWithClassAnimations", format("models/player/%s.mdl", class_string), SINGLE_TICK, null, null)
-		    EntFireByHandle(bot, "RunScriptCode", format("PopExtUtil.PlayerRobotModel(self, `models/bots/heavy/bot_heavy.mdl`)", class_string, class_string), SINGLE_TICK, null, null)
-        },
-        OnDeath = function(bot, params) {
-            EntFireByHandle(bot, "SetCustomModelWithClassAnimations", "models/bots/heavy/bot_heavy.mdl", -1, null, null)
-        }
-    })
-
-    PopExt.AddRobotTag("bot_heavygiant", {
-        OnSpawn = function(bot, tag) {
-            local class_string = PopExtUtil.Classes[bot.GetPlayerClass()]
-           	EntFireByHandle(bot, "SetCustomModelWithClassAnimations", format("models/player/%s.mdl", class_string), SINGLE_TICK, null, null)
-		    EntFireByHandle(bot, "RunScriptCode", format("PopExtUtil.PlayerRobotModel(self, `models/bots/heavy_boss/bot_heavy_boss.mdl`)", class_string, class_string), SINGLE_TICK, null, null)
-        },
-        OnDeath = function(bot, params) {
-            EntFireByHandle(bot, "SetCustomModelWithClassAnimations", "models/bots/heavy_boss/bot_heavy_boss.mdl", -1, null, null)
-        }
-    })
+PopExt.AddRobotTag("bot_heavygiant", {
+	OnSpawn = function(bot, _) {
+		bot.SetCustomModelWithClassAnimations("models/player/" + PopExtUtil.Classes[bot.GetPlayerClass()] + ".mdl")
+		PopExtUtil.PlayerRobotModel(bot, "models/bots/heavy_boss/bot_heavy_boss.mdl")
+	},
+	OnDeath = function(bot, _)
+		bot.SetCustomModelWithClassAnimations("models/bots/heavy_boss/bot_heavy_boss.mdl")
+})


### PR DESCRIPTION
The mission currently does not convert all bots to appear as Heavy bots, and has some VScript errors.

Note: This PopExt+ version on Archive should be updated before this PR is merged, which will fix the [`Explanation()` recursion error](https://github.com/potato-tf/PopExtensionsPlus/commit/24b3e1c).

- Now includes `mvm_saxford_rc1_adv_grim_memorial_tags.nut` in every `InitWaveOutput` as PopExt+ no longer does this automatically.
- Updated the methods used in `..._tags.nut` following the addition of `GetAllBotTags()` and `SetCustomModelWithClassAnimations()` natives.
- `Info()` -> `PopExtUtil.Info()`.