### PR TITLE
Update mvm_whitecliff_event_rc2_exp_light_up_the_night.pop

### DIFF
--- a/scripts/population/mvm_whitecliff_event_rc2_exp_light_up_the_night.pop
+++ b/scripts/population/mvm_whitecliff_event_rc2_exp_light_up_the_night.pop
@@ -7010,6 +7010,7 @@ Real?
 				"cannot be sapped"			1	// i mean what is timebomb sapping this guy going to do anyways
 				"damage force reduction"	0.01
 				"airblast vulnerability multiplier"	0.01		
+				"force distribute currency on death"	1
 			}
 
 			FireInput   
@@ -7972,7 +7973,7 @@ Real?
 				"projectile detonate time"	4
 				"no damage falloff"			1
 				"projectile acceleration time"	0.5
-				"projectile acceleration"		-1100
+				"projectile acceleration"		-2000
 				"projectile speed increased"	1
 				"mult explosion radius direct hit" 0.2
 				"clip size bonus"	2


### PR DESCRIPTION
- small fix that makes chief viper spy always drop red money because apparently people keep losing his money when he dies somewhere if you don't kill him at any point during the wave
- additional fix to chief guttertank's rockets