### PR TITLE
Update mvm_downtown_final4b_adv_666_one_down.pop

### DIFF
--- a/scripts/population/mvm_downtown_final4b_adv_666_one_down.pop
+++ b/scripts/population/mvm_downtown_final4b_adv_666_one_down.pop
@@ -4,6 +4,7 @@
 
 // 2024 update: fixed gatebot quickfix medics softlocking the wave by replacing them with the non-gatebot quickfix medic template, gave sentrybusters the bot_giant tag and changed persian demoknight icon
 
+// 2025 update: Scaled final boss to default 1.75 scale from 1.8 scale to fix potential softlock if he tries to spawn in gate B. See: https://www.youtube.com/watch?v=5dB-tHD0LMM
 #base robot_giant.pop
 #base robot_standard.pop
 #base robot_gatebot.pop
@@ -792,7 +793,7 @@ population
 			ClassIcon soldier_major_crits
 			Skill Expert
 			Health 50000
-			Scale 1.8
+			//Scale 1.8
 			WeaponRestrictions PrimaryOnly
 			Attributes "MiniBoss"
 			Attributes "UseBossHealthBar"


### PR DESCRIPTION
Fix final subwave boss softlock by reducing its scale from 1.8 to 1.75.