### PR TITLE
Update to mvm_meltdown_rc5_exp_lights_out.pop

### DIFF
--- a/scripts/population/mvm_meltdown_rc5_exp_lights_out.pop
+++ b/scripts/population/mvm_meltdown_rc5_exp_lights_out.pop
@@ -449,12 +449,8 @@ Templates
 		ItemAttributes
 		{
 			ItemName "The Reserve Shooter"
-			"fire rate bonus" 0.9
-			"bullets per shot bonus" 10
-			"damage penalty" 0.6
 			"passive reload" 1
 			"faster reload rate" 0.01
-			"weapon spread bonus" 0.6
 		}
 		CharacterAttributes
 		{


### PR DESCRIPTION
Removed extra stats from blast combo chief due to them being cancerous