### PR TITLE
Fix mvm_kelly_rc1b_adv_awakening.pop

### DIFF
--- a/scripts/population/mvm_kelly_rc1b_adv_awakening.pop
+++ b/scripts/population/mvm_kelly_rc1b_adv_awakening.pop
@@ -233,10 +233,12 @@ WaveSchedule
             "SPELL: set Halloween footstep type"	"13595446"
         }
         Engineer
+		// CAUSES CRASHES ON GUNSLINGER.
+		// See ItemAttributes for applying this to non-gunslinger wrenches.
         {
             "voice pitch scale"            0.90
-            "SPELL: Halloween pumpkin explosions"   1
-            "attach particle effect"        12
+            "SPELL: Halloween pumpkin explosions"   1 
+            //"attach particle effect"        12 //<- CRASHES ON GUNSLINGER.
         }
         Heavyweapons
         {
@@ -264,6 +266,12 @@ WaveSchedule
             "attach particle effect"        12
         }
     }
+
+	ItemAttributes //So that the gunslinger fix only visually changes the gunslinger, and not the non-crashy wrenches.
+	{
+		Classname tf_weapon_wrench // All non-gunslinger wrenches.
+		"attach particle effect"        12
+	}
 
     PointTemplates
     {


### PR DESCRIPTION
Fixed gunslinger crash while doing as little collateral damage as possible. Done with written permission from CreatorForce who made the original mission.