### PR TITLE
Reboot Rush: Remove redundant open/close inputs to resupply locker

### DIFF
--- a/scripts/population/mvm_akure_rc1a_adv_reboot_rush.pop
+++ b/scripts/population/mvm_akure_rc1a_adv_reboot_rush.pop
@@ -147,8 +147,8 @@ WaveSchedule
 				"TeamNum"         "2"
 				"spawnflags"      "1"
 				
-				"OnStartTouch"  "cabinet,SetAnimation,open,0,-1"
-				"OnEndTouchAll" "cabinet,SetAnimation,close,0,-1"
+		//		"OnStartTouch"  "cabinet,SetAnimation,open,0,-1"
+		//		"OnEndTouchAll" "cabinet,SetAnimation,close,0,-1"
 			}
 			filter_activator_tfteam
 			{


### PR DESCRIPTION
Handled automatically by func_regenerate and stops the animation from bugging out.