### PR TITLE
Update mvm_robotfactory_b30_rev_adv_short_circuit_execution.pop

### DIFF
--- a/scripts/population/mvm_robotfactory_b30_rev_adv_short_circuit_execution.pop
+++ b/scripts/population/mvm_robotfactory_b30_rev_adv_short_circuit_execution.pop
@@ -33,6 +33,7 @@ WaveSchedule
 	BonusRatioHalf 2	//no bonus
 	BonusRatioFull 2
 	ForceRedMoney 1 //collecting money as an engie is suffering
+	//luascriptfile "scripts/scroob_custom_upgrade_hurt_listener.lua"
 
 	AllowJoinTeamBlueMax 6 
 	RespawnWaveTimeBlue 			1
@@ -218,8 +219,8 @@ WaveSchedule
 				ItemName "The Claidheamohmor"
 				"paintkit_proto_def_index" 414
 				"set_item_texture_wear" 0
-				"melee range multiplier" 1.2
-				"hand scale" 1.25
+				"provide on active" 1
+				"switch from wep deploy time decreased" 0.5
 				"damage bonus"	1.5
 			}
 			ItemAttributes
@@ -241,7 +242,6 @@ WaveSchedule
 			}
 			CharacterAttributes
 			{
-			"deploy time increased" 0.01
 			"charge time increased" 2
 			"charge recharge rate increased" 1.25
 			"head scale" 0.7
@@ -287,8 +287,8 @@ WaveSchedule
 					ItemName "The Claidheamohmor"
 					"paintkit_proto_def_index" 414
 					"set_item_texture_wear" 0
-					"melee range multiplier" 1.2
-					"hand scale" 1.25
+					"provide on active" 1
+					"switch from wep deploy time decreased" 0.5
 					"damage bonus"	1.5 //nerfed because, while funny, one shotting spies and scouts is kinda problematic
 				}
 				ItemAttributes
@@ -311,7 +311,6 @@ WaveSchedule
 				}
 				CharacterAttributes
 				{
-				"deploy time increased" 0.01
 				"charge time increased" 3 //nerfed due to them displacing themselves like morons
 				"charge recharge rate increased" 1.25
 				"move speed bonus"	0.5
@@ -351,12 +350,8 @@ WaveSchedule
 			ItemAttributes
 			{
 				ItemName "The Reserve Shooter"
-				"fire rate bonus" 0.9
-				"bullets per shot bonus" 10
-				"damage penalty" 0.6
 				"passive reload" 1
 				"faster reload rate" 0.01
-				"weapon spread bonus" 0.35
 			}
 			CharacterAttributes
 			{
@@ -1015,6 +1010,7 @@ WaveSchedule
 								"sniper no headshots" 1 //dummy attrs to lock onto with lua.
 								"cancel falling damage" 1
 								"duckstreaks active" 1
+								"voice pitch scale"	0
 								"dmg taken mult from special damage type 2" 2.5
 							}
 							Item "Tyrantium Helmet"
@@ -1075,6 +1071,7 @@ WaveSchedule
 								"sniper no headshots" 1 //dummy attrs to lock onto with lua.
 								"duckstreaks active" 1
 								"cancel falling damage" 1
+								"voice pitch scale"	0
 								"dmg taken mult from special damage type 2" 2.5
 							}
 							Item "Tyrantium Helmet"
@@ -1135,6 +1132,7 @@ WaveSchedule
 								"sniper no headshots" 1 //dummy attrs to lock onto with lua.
 								"duckstreaks active" 1
 								"cancel falling damage" 1
+								"voice pitch scale"	0
 								"dmg taken mult from special damage type 2" 2.5
 							}
 							Item "Tyrantium Helmet"
@@ -1526,6 +1524,8 @@ WaveSchedule
 								"cancel falling damage" 1
 								"duckstreaks active" 1
 								"dmg taken mult from special damage type 2" 2.5
+								"voice pitch scale"	2
+								"use robot voice" 1
 							}
 							Item "Tyrantium Helmet"
 							ItemAttributes
@@ -1586,6 +1586,8 @@ WaveSchedule
 								"duckstreaks active" 1
 								"cancel falling damage" 1
 								"dmg taken mult from special damage type 2" 2.5
+								"voice pitch scale"	2
+								"use robot voice" 1
 							}
 							Item "Tyrantium Helmet"
 							ItemAttributes
@@ -1646,6 +1648,8 @@ WaveSchedule
 								"duckstreaks active" 1
 								"cancel falling damage" 1
 								"dmg taken mult from special damage type 2" 2.5
+								"voice pitch scale"	2
+								"use robot voice" 1
 							}
 							Item "Tyrantium Helmet"
 							ItemAttributes
@@ -1655,7 +1659,7 @@ WaveSchedule
 							}
 						}						
 					}
-				}				
+				}					
 				T_TFBot_Giant_Soldier_Spammer_Reload_Two_Stage
 				{
 					Class Soldier
@@ -1826,7 +1830,7 @@ WaveSchedule
 	
 	"special item description" "Scout giants aren't the heavy hitters soldiers, demos, heavies and pyros are, so some of that beefiness goes onto you instead!"
 	"special item description 2" "[TIERS] 1: Giant Scout, 2: Giant Shortstop Scout, 3: Giant Shove-stop Scout, 4: Giant Giga Scout"
-	"special item description 3" "Wrench allies to heal them, hold reload with any active weapon to park your giant"
+	"special item description 3" "Wrench allies to heal them, hold med shield key with any active weapon to park your giant"
 	}
 	ItemAttributes
 	{
@@ -1840,7 +1844,7 @@ WaveSchedule
 	
 	"special item description" "Heavy giants are indomitable forces of destruction, you sacrifice 50 health in exchange for this awesome power!"
 	"special item description 2" "[TIERS] 1: Giant Heavy, 2: Giant Deflector Heavy, 3: Giant Heater Heavy, 4: Giant EMP Heavy"
-	"special item description 3" "Wrench allies to heal them, hold reload with any active weapon to park your giant"
+	"special item description 3" "Wrench allies to heal them, hold hold med shield key with any active weapon to park your giant"
 	}
 	ItemAttributes
 	{
@@ -1850,7 +1854,7 @@ WaveSchedule
 	
 	"special item description" "Demo giants pack significant firepower, but are a little less durable and a bit faster than their heavier soldier cousins"
 	"special item description 2" "[TIERS] 1: Giant Rapid Fire Demo, 2: Giant Hybrid Knight, 3: Giant Rammer Knight, 4: Giant Burst Knight"
-	"special item description 3" "Wrench allies to heal them, hold reload with any active weapon to park your giant"
+	"special item description 3" "Wrench allies to heal them, hold med shield key with any active weapon to park your giant"
 	}
 	ItemAttributes
 	{
@@ -1869,7 +1873,7 @@ WaveSchedule
 	
 	"special item description" "Pyro giants are strange, they are as durable as soldiers and as fast as demos, yet worse than both. You become exponentially stronger to compensate!"
 	"special item description 2" "[TIERS] 1: Giant Pyro, 2: Giant Airblast Pyro, 3: Giant Fuel Injected Pyro (fast), 4: Fury (Dragon's Fury that hits like a gigaburst)"
-	"special item description 3" "Wrench allies to heal them, hold reload with any active weapon to park your giant"
+	"special item description 3" "Wrench allies to heal them, hold med shield key with any active weapon to park your giant"
 	}
 	ItemAttributes
 	{
@@ -1878,7 +1882,7 @@ WaveSchedule
 	
 	"special item description" "Soldiers are middle of the road giants, good firepower, good speed (for their size), and good durability."
 	"special item description 2" "[TIERS] 1: Giant Soldier, 2: Giant Burst Soldier, 3: Giant Charged Soldier, 4: Giant Rapid Fire Soldier"
-	"special item description 3" "Wrench allies to heal them, hold reload with any active weapon to park your giant"
+	"special item description 3" "Wrench allies to heal them, hold med shield key with any active weapon to park your giant"
 	}
 	ItemAttributes
 	{
@@ -1887,7 +1891,7 @@ WaveSchedule
 	
 	"special item description" "Soldiers are middle of the road giants, good firepower, good speed (for their size), and good durability."
 	"special item description 2" "[TIERS] 1: Giant Soldier, 2: Giant Burst Soldier, 3: Giant Charged Soldier, 4: Giant Rapid Fire Soldier"
-	"special item description 3" "Wrench allies to heal them, hold reload with any active weapon to park your giant"
+	"special item description 3" "Wrench allies to heal them, hold med shield key with any active weapon to park your giant"
 	}	
 	
 	
@@ -1936,6 +1940,20 @@ WaveSchedule
 	
 	PointTemplates
 {
+	nameChange
+		{ 
+			logic_relay
+			{
+				"targetname" "nameChange"
+				"origin" "0 0 0"
+				"OnTrigger" "tf_objective_resource,$SetClientProp$m_iszMvMPopfileName,ADV Short Circuit Execution,0,-1"
+			}
+			OnSpawnOutput
+			{
+				Target "nameChange" 
+				Action trigger
+			}
+		}	
 	LoseRelay 
 	{
 		NoFixup 1
@@ -2010,6 +2028,24 @@ WaveSchedule
             {
                 Target "boss_grey_glow"
                 Action "Kill"
+            }
+		}		
+		//AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAH
+		GreyGlowsMK1
+		{
+            OnSpawnOutput
+            {
+            target "!activator"
+            action "$setclientprop$m_bGlowEnabled"
+            param "1"
+            Delay 0.01
+            }
+            OnParentKilledOutput
+            {
+            target "!activator"
+            action "$setclientprop$m_bGlowEnabled"
+            param "0"
+            Delay 0.01
             }
 		}
 		W1_Timer //wave 1 timer, originally made by Braindawg
@@ -2217,7 +2253,7 @@ WaveSchedule
 				"switch_teams" "0"
 				"force_map_reset" "1"
 			}
-		}		
+		}
 		wave1_initialization_relay //fires all the relays to set up the map, and places spawnpoint covers
 		{
 			logic_relay
@@ -2226,6 +2262,7 @@ WaveSchedule
 				"onspawn" "objective1_0_glow,Enable,,0,-1"
 				"onspawn" "popscript,$ResetGigaDispCount,,0,-1"
 				"onspawn" "A_route_wall_4_fix_relay,Trigger,,0,-1"
+				"onspawn"  "A_route_wall_3_fix_relay,Trigger,,0,-1"				
 				"onspawn" "hatch_shortcut_A_fix_relay,Trigger,,0,-1"
 				"onspawn" "relay_C,Trigger,,0,-1"
 				"onspawn" "spawnbot_red*,Disable,,0,-1"
@@ -2391,7 +2428,6 @@ WaveSchedule
 				"mins" "-5500 -50 -600"
 				"maxs" "5500 5 1100"
 				"StartDisabled" "0"
-				"rendermode" "10"
 			}
 			func_nobuild
 			{
@@ -2429,7 +2465,6 @@ WaveSchedule
 				"mins" "-1100 -50 -600"
 				"maxs" "1100 5 300"
 				"StartDisabled" "0"
-				"rendermode" "10"
 			}
 			func_nobuild
 			{
@@ -2479,7 +2514,6 @@ WaveSchedule
 				"mins" "-50 -1000 -1000"
 				"maxs" "5 1000 1000"
 				"StartDisabled" "0"
-				"rendermode" "10"
 			}	
 						func_nobuild
 			{
@@ -2489,45 +2523,6 @@ WaveSchedule
 				"maxs" "5 1000 1000"
 				"StartDisabled" "0"
 			}			
-			prop_dynamic //so you can see it from both sides
-			{
-				modelscale 1.2
-				model "models/props_mvm/reversemvm_redwall_640x418.mdl"
-				//measurements 640X300 176X120 176X152 256X288
-				"origin" "-0.54 -413.47 2.73"
-				angles "0 0 0"
-				targetname "NeverShields"
-				disableshadows 1
-			}
-			
-			prop_dynamic //so you can see it from both sides
-			{
-				modelscale 1.2
-				model "models/props_mvm/reversemvm_redwall_640x418.mdl"
-				//measurements 640X300 176X120 176X152 256X288
-				"origin" "-0.54 -413.47 2.73"
-				angles "0 180 0"
-				targetname "NeverShields"
-				disableshadows 1
-			}			
-						func_forcefield
-			{
-				"origin" "-0.54 -413.47 2.73"
-				"TeamNum" "2"
-				"targetname" "NeverShields"
-				"mins" "-300 -50 -300"
-				"maxs" "300 5 300"
-				"StartDisabled" "0"
-				"rendermode" "10"
-			}
-						func_nobuild
-			{
-				"origin" "-0.54 -413.47 2.73"
-				"targetname" "NeverShields"
-				"mins" "-300 -50 -300"
-				"maxs" "300 5 300"
-				"StartDisabled" "0"
-			}
 			
 			
 			
@@ -2550,7 +2545,6 @@ WaveSchedule
 				"mins" "-300 -50 -300"
 				"maxs" "300 5 300"
 				"StartDisabled" "0"
-				"rendermode" "10"
 			}
 						func_nobuild
 			{
@@ -2590,7 +2584,6 @@ WaveSchedule
 				"mins" "-1000 -50 -1000"
 				"maxs" "1000 5 1000"
 				"StartDisabled" "0"
-				"rendermode" "10"
 			}
 						func_nobuild
 			{
@@ -2620,7 +2613,6 @@ WaveSchedule
 				"mins" "-50 -800 -800"
 				"maxs" "5 800 800"
 				"StartDisabled" "0"
-				"rendermode" "10"
 			}
 						func_nobuild
 			{
@@ -2683,7 +2675,6 @@ WaveSchedule
 				"mins" "-50 -375 -375"
 				"maxs" "5 375 375"
 				"StartDisabled" "0"
-				"rendermode" "10"
 			}
 			func_nobuild
 			{
@@ -2722,7 +2713,6 @@ WaveSchedule
 				"mins" "-50 -375 -105"
 				"maxs" "5 375 375"
 				"StartDisabled" "0"
-				"rendermode" "10"
 			}
 			
 			func_forcefield
@@ -2733,7 +2723,6 @@ WaveSchedule
 				"mins" "-1100 -50 -600"
 				"maxs" "1100 5 1100"
 				"StartDisabled" "0"
-				"rendermode" "10"
 			}
 			func_nobuild
 			{
@@ -2835,6 +2824,7 @@ WaveSchedule
 			{
 				"targetname" "wave2_initialization_relay" //map changes
 				"onspawn" "hatch_shortcut_A_fix_relay,Trigger,,0,-1"
+				"onspawn" "vip_teleport_relay,Trigger,,0.5,-1"
 				"onspawn" "A_route_wall_4_fix_relay,Trigger,,0,-1"
 				"onspawn"  "A_route_wall_3_fix_relay,Trigger,,0,-1"
 				"onspawn" "spawner_wave2,enable,,0,1" //spawn covers
@@ -3005,7 +2995,6 @@ WaveSchedule
 				"mins" "-50 -375 -105"
 				"maxs" "5 375 375"
 				"StartDisabled" "0"
-				"rendermode" "10"
 			}	
 						func_nobuild
 			{
@@ -3065,7 +3054,6 @@ WaveSchedule
 				"mins" "-390 -50 -390"
 				"maxs" "390 5 390"
 				"StartDisabled" "0"
-				"rendermode" "10"
 			}
 						func_nobuild
 			{
@@ -3097,7 +3085,6 @@ WaveSchedule
 				"mins" "-300 -50 -300"
 				"maxs" "300 50 300"
 				"StartDisabled" "0"
-				"rendermode" "10"
 			}
 						func_nobuild
 			{
@@ -3135,7 +3122,6 @@ WaveSchedule
 				"mins" "-50 -1000 -1000"
 				"maxs" "5 1000 1000"
 				"StartDisabled" "0"
-				"rendermode" "10"
 			}
 						func_nobuild
 			{
@@ -3177,6 +3163,7 @@ WaveSchedule
 			"OnTrigger" "spawnbot_red_mirror2*,Disable,,0,-1"	
 			"OnTrigger" "spawnbot_red_mirror3*,Enable,,5,-1"	
 			"OnTrigger" "wave2_gametext_2,Display,,0,-1"
+			"OnTrigger" "w2_teleporter,Enable,,0,-1"
 			"OnTrigger" "player,$PlaySoundToSelf,mobocracy/rescue.wav,0,-1"
 			"OnTrigger" "tf_point_nav_interface,recomputeblockers,,0,-1"	
 			}
@@ -3403,6 +3390,26 @@ WaveSchedule
 				"onstarttouch" "objective2_start_mid,trigger,,0.01,-1"
 				"origin" "-1322.86 259.01 196.11"
 			}
+			trigger_teleport
+			{
+				targetname "w2_teleporter"
+				"origin" "-1105.18 -622.63 7.36"
+				"mins" "-250 -250 -250"
+				"maxs" "250 250 250"
+				target "w2_teleporter_destination"
+				//Thanks ficool
+				"OnStartTouch" "!activatorRunScriptCodeself.AddCondEx(57, 3, null)-1-1"
+				"OnStartTouch" "player,$PlaySoundToSelf,"mvm\mvm_tele_deliver.wav",0,-1"
+				"spawnflags" "1"
+				"filtername" "filter_vip"
+				StartDisabled 1
+			}
+			info_teleport_destination
+			{
+				targetname "w2_teleporter_destination"
+				origin "-324.78 1401.32 32"
+				angles "0 -45 0"
+			}			
 			trigger_once
 			{
 				"targetname" "vipDetect1"
@@ -3451,7 +3458,6 @@ WaveSchedule
 				"mins" "-300 -50 -300"
 				"maxs" "300 5 300"
 				"StartDisabled" "0"
-				"rendermode" "10"
 			}
 						func_nobuild
 			{
@@ -3483,7 +3489,6 @@ WaveSchedule
 				"mins" "-300 -50 -300"
 				"maxs" "300 5 300"
 				"StartDisabled" "0"
-				"rendermode" "10"
 			}
 						func_nobuild
 			{
@@ -3523,7 +3528,6 @@ WaveSchedule
 				"mins" "-1000 -50 -1000"
 				"maxs" "1000 5 1000"
 				"StartDisabled" "0"
-				"rendermode" "10"
 			}
 						func_nobuild
 			{
@@ -3553,7 +3557,6 @@ WaveSchedule
 				"mins" "-50 -800 -800"
 				"maxs" "5 800 800"
 				"StartDisabled" "0"
-				"rendermode" "10"
 			}
 						func_nobuild
 			{
@@ -3691,7 +3694,6 @@ WaveSchedule
 				"mins" "-1000 -50 -1000"
 				"maxs" "1000 5 1000"
 				"StartDisabled" "0"
-				"rendermode" "10"
 			}
 						func_nobuild
 			{
@@ -3739,7 +3741,6 @@ WaveSchedule
 				"mins" "-50 -1000 -1000"
 				"maxs" "5 1000 1000"
 				"StartDisabled" "0"
-				"rendermode" "10"
 			}
 						func_nobuild
 			{
@@ -3767,7 +3768,6 @@ WaveSchedule
 				"mins" "-300 -50 -300"
 				"maxs" "300 50 300"
 				"StartDisabled" "0"
-				"rendermode" "10"
 			}
 						func_nobuild
 			{
@@ -3809,7 +3809,6 @@ WaveSchedule
 				"mins" "-390 -50 -390"
 				"maxs" "390 5 390"
 				"StartDisabled" "0"
-				"rendermode" "10"
 			}
 						func_nobuild
 			{
@@ -3841,7 +3840,6 @@ WaveSchedule
 				"mins" "-300 -50 -300"
 				"maxs" "300 5 300"
 				"StartDisabled" "0"
-				"rendermode" "10"
 			}				
 						func_nobuild
 			{
@@ -4577,7 +4575,7 @@ WaveSchedule
                 "renderamt" "255"
                 "rendercolor" "255 255 255"
                 "renderfx" "0"
-				"rendermode" "10"
+                "rendermode" "0"
                 "disablereceiveshadows" "0"
 
                 "mins" "-48.1 -48.1 32.825"
@@ -4845,7 +4843,6 @@ WaveSchedule
 					maxs "300 5 300"
 					teamnum 2
 					StartDisabled 0
-					rendermode 10
 				}
 				prop_dynamic
 				{
@@ -4906,7 +4903,7 @@ WaveSchedule
 				"origin" "-1027.63, 3823.31, 230.24"
 				"angles" "0, 0, 0"
 				"targetname" "informationText5"
-				"message" "Note: you can wrench your allies, hold reload to park your giant"
+				"message" "Note: you can wrench your allies, hold your med shield key to park your giant"
 				"font" "1"
 				"Color" "0 255 0 255"
 				"textsize" "6"
@@ -4974,7 +4971,7 @@ WaveSchedule
 				"origin" "-2670.47, 2738.51, -88.58"
 				"angles" "0, 45, 0"
 				"targetname" "informationText5"
-				"message" "Note: you can wrench your allies, hold reload to park your giant"
+				"message" "Note: you can wrench your allies, hold med shield key to park your giant"
 				"font" "1"
 				"Color" "0 255 0 255"
 				"textsize" "6"
@@ -5043,7 +5040,7 @@ WaveSchedule
 				"origin" "-256.61, 2161.35, -146.63"
 				"angles" "0, -90, 0"
 				"targetname" "informationText5"
-				"message" "Note: you can wrench your allies, hold reload to park your giant"
+				"message" "Note: you can wrench your allies, hold med shield key to park your giant"
 				"font" "1"
 				"Color" "0 255 0 255"
 				"textsize" "6"
@@ -5195,8 +5192,6 @@ WaveSchedule
 				"onspawn" "tube_bot_spawn,disable,,0,1" //never seen this happen, but that doesn't mean it can't happen
 				"onspawn" "jumppad_slideing_door,Lock,0,1"
 				"onmapspawn" "cap_master,SetCapLayoutCustomPositionY,999,0,-1"
-				"OnSpawn" "B2_door_open_relay,Kill,,-1,-1"
-				"OnSpawn" "B2_door_trigger_close,Trigger,,-1,-1"
 				}			
 				prop_dynamic
 				{
@@ -6863,7 +6858,7 @@ WaveSchedule
 				Cap 2
 				Increment 0.25
 				Attribute "weapon burn dmg increased"
-				Description "Increase afterburn duration by 25% and afterburn damage by 15% per increment"
+				Description "Increase afterburn duration by 15% and afterburn damage by 25% per increment"
 				Cost 125
 				AllowedWeapons
 				{
@@ -7114,6 +7109,7 @@ WaveSchedule
 			SpawnTemplate LaserOnAim
 		}
 	}
+	SpawnTemplate "nameChange"
 	
 
 	// WAVE 1 [$0]
@@ -7136,7 +7132,7 @@ WaveSchedule
 				Line "{CCCCFF}Your sentries have been replaced with powerful {00FF00}Giant Robots{FFFF00} Inspect your wrench!"
 				Line "{CCCCFF}The objective this wave is to repair 5 {00FF00}GIGA DISPENSERS{CCCCFF} around the map"
 				Line "{CCCCFF}You have {FF9999}six minutes {CCCCFF}to perform this objective"
-				Line "{CCCCFF}Note: {FFFF00}you can wrench your allies, hold reload to park your giant"
+				Line "{CCCCFF}Note: {FFFF00}you can wrench your allies, hold med shield button to park your giant"
 				Line ""
 				Line "{CCCCFF}Your allies consist of: {00FF00}2 Giant Soldiers"
 				Line ""
@@ -7430,7 +7426,7 @@ WaveSchedule
 				WaveSpawn
 		{
 			Name  "wave01b"
-			Where spawnbot_red_mirror1_hatch_shortcut_a
+			Where spawnbot_red_mirror1_b1
 
 			TotalCount 2
 			MaxActive  1
@@ -7884,7 +7880,7 @@ WaveSchedule
 					Param ""
 					Delay 0
 					Repeats 1
-				}				
+				}
 			}
 				DoneOutput
 			{
@@ -9834,6 +9830,7 @@ WaveSchedule
 			UseMeleeThreatPrioritization 1
 			MaxVisionRange 1200
 			Addcond { Name TF_COND_REPROGRAMMED_NEUTRAL }
+			SpawnTemplate "GreyGlowsMK1"
 			CustomEyeGlowColor "255 255 255"
 			Action Mobber
 			Attributes DisableDodge
@@ -9885,6 +9882,7 @@ WaveSchedule
 				UseMeleeThreatPrioritization 1
 				MaxVisionRange 1200
 				Addcond { Name TF_COND_REPROGRAMMED_NEUTRAL }
+				SpawnTemplate "GreyGlowsMK1"
 				Action Mobber
 				Attributes DisableDodge
 				UseCustomModel "models/bots/soldier/bot_soldier_gray.mdl"
@@ -9913,6 +9911,7 @@ WaveSchedule
 				UseMeleeThreatPrioritization 1
 				MaxVisionRange 1200
 				Addcond { Name TF_COND_REPROGRAMMED_NEUTRAL }
+				SpawnTemplate "GreyGlowsMK1"
 				Action Mobber
 				Attributes DisableDodge
 				UseCustomModel "models/bots/soldier/bot_soldier_gray.mdl"
@@ -9941,6 +9940,7 @@ WaveSchedule
 				UseMeleeThreatPrioritization 1
 				MaxVisionRange 1200
 				Addcond { Name TF_COND_REPROGRAMMED_NEUTRAL }
+				SpawnTemplate "GreyGlowsMK1"
 				CustomEyeGlowColor "255 255 255"
 				Action Mobber
 				Attributes DisableDodge
@@ -9970,6 +9970,7 @@ WaveSchedule
 				UseMeleeThreatPrioritization 1
 				MaxVisionRange 1200
 				Addcond { Name TF_COND_REPROGRAMMED_NEUTRAL }
+				SpawnTemplate "GreyGlowsMK1"
 				Action Mobber
 				Attributes DisableDodge
 				UseCustomModel "models/bots/soldier/bot_soldier_gray.mdl"
@@ -9998,6 +9999,7 @@ WaveSchedule
 				UseMeleeThreatPrioritization 1
 				MaxVisionRange 1200
 				Addcond { Name TF_COND_REPROGRAMMED_NEUTRAL }
+				SpawnTemplate "GreyGlowsMK1"
 				Action Mobber
 				Attributes DisableDodge
 				UseCustomModel "models/bots/demo/bot_demo_gray.mdl"
@@ -10031,6 +10033,7 @@ WaveSchedule
 				UseMeleeThreatPrioritization 1
 				MaxVisionRange 1200
 				Addcond { Name TF_COND_REPROGRAMMED_NEUTRAL }
+				SpawnTemplate "GreyGlowsMK1"
 				Action Mobber
 				Attributes DisableDodge
 				UseCustomModel "models/bots/demo/bot_demo_gray.mdl"
@@ -10064,6 +10067,7 @@ WaveSchedule
 				UseMeleeThreatPrioritization 1
 				MaxVisionRange 1200
 				Addcond { Name TF_COND_REPROGRAMMED_NEUTRAL }
+				SpawnTemplate "GreyGlowsMK1"
 				CustomEyeGlowColor "255 255 255"
 				Action Mobber
 				Attributes DisableDodge
@@ -10098,6 +10102,7 @@ WaveSchedule
 				UseMeleeThreatPrioritization 1
 				MaxVisionRange 1200
 				Addcond { Name TF_COND_REPROGRAMMED_NEUTRAL }
+				SpawnTemplate "GreyGlowsMK1"
 				CustomEyeGlowColor "255 255 255"
 				Action Mobber
 				Attributes DisableDodge
@@ -10195,6 +10200,7 @@ WaveSchedule
 			UseMeleeThreatPrioritization 1
 			MaxVisionRange 1200
 			Addcond { Name TF_COND_REPROGRAMMED_NEUTRAL }
+			SpawnTemplate "GreyGlowsMK1"
 			CustomEyeGlowColor "255 255 255"
 			Action Mobber
 			Attributes DisableDodge
@@ -10264,7 +10270,9 @@ WaveSchedule
 			UseMeleeThreatPrioritization 1
 			MaxVisionRange 1200
 			Addcond { Name TF_COND_REPROGRAMMED_NEUTRAL }
+			SpawnTemplate "GreyGlowsMK1"
 			CustomEyeGlowColor "255 255 255"
+			SpawnTemplate "GreyGlowsMK1"
 			Action Mobber
 			Attributes DisableDodge
 			UseCustomModel "models/bots/soldier/bot_soldier_gray.mdl"
@@ -10338,6 +10346,7 @@ WaveSchedule
 				Action Mobber
 				Attributes DisableDodge
 				Skill Expert // increased to improve ability to hit with melee
+				SpawnTemplate "GreyGlowsMK1"
 				ItemAttributes
 				{
 				ItemName "The Eyelander"
@@ -10407,6 +10416,7 @@ WaveSchedule
 				Template T_TFBot_Demo_Burst
 				UseCustomModel "models/bots/demo/bot_demo_gray.mdl"
 				UseMeleeThreatPrioritization 1
+				SpawnTemplate "GreyGlowsMK1"
 				Action Mobber
 				Attributes DisableDodge
 				Skill Expert
@@ -10468,6 +10478,7 @@ WaveSchedule
 				UseMeleeThreatPrioritization 1
 				MaxVisionRange 1200
 				Addcond { Name TF_COND_REPROGRAMMED_NEUTRAL }
+				SpawnTemplate "GreyGlowsMK1"
 				CustomEyeGlowColor "255 255 255"
 				Action Mobber
 				Attributes DisableDodge
@@ -10530,6 +10541,7 @@ WaveSchedule
 				UseMeleeThreatPrioritization 1
 				MaxVisionRange 1200
 				Addcond { Name TF_COND_REPROGRAMMED_NEUTRAL }
+				SpawnTemplate "GreyGlowsMK1"
 				Action Mobber
 				Attributes DisableDodge
 				UseCustomModel "models/bots/soldier/bot_soldier_gray.mdl"
@@ -10598,6 +10610,7 @@ WaveSchedule
 				UseMeleeThreatPrioritization 1
 				MaxVisionRange 1200
 				Addcond { Name TF_COND_REPROGRAMMED_NEUTRAL }
+				SpawnTemplate "GreyGlowsMK1"
 				CustomEyeGlowColor "255 255 255"
 				Action Mobber
 				Attributes DisableDodge
@@ -10776,6 +10789,7 @@ WaveSchedule
 				UseMeleeThreatPrioritization 1
 				MaxVisionRange 1200
 				Addcond { Name TF_COND_REPROGRAMMED_NEUTRAL }
+				SpawnTemplate "GreyGlowsMK1"
 				CustomEyeGlowColor "255 255 255"
 				Action Mobber
 				Attributes DisableDodge


### PR DESCRIPTION
1. Nerfed blast combo boss to the same level as the one on lights out
2. Nerfed zweihander templates to no longer instantly switch, and to not have longer range
3. Attempted to fix issue where the VIP on w2 would softlock the wave by running into the forcefield, I have done so by adding a teleport trigger that will teleport the boss away from that forcefield and near the location he is supposed to walk to.
4. Added voicepitch 0 to monochrome so that he doesn't make human pain noises, added voicepitch 2 and use robot voice to MonOwOchrome because that seems fitting.
5. Corrected miscellaneous description inaccuracies.