### PR TITLE
wave 3 softlock fix

### DIFF
--- a/scripts/population/mvm_tensai_rc5_adv_scarlet_embodiment.pop
+++ b/scripts/population/mvm_tensai_rc5_adv_scarlet_embodiment.pop
@@ -6,10 +6,10 @@ population
 	ExtraSpawnPoint [$SIGSEGV]  //Don't wanna use sigmod but whatever
     {
         Name "whatever"
-        TeamNum 3 
-        X	"-145"                     
-        Y	"-36"                  
-        Z	"180"        
+        TeamNum 3
+        X	"534"                     
+        Y	"-15"                  
+        Z	"-66"        
     }
 	ExtraSpawnPoint [$SIGSEGV]  //Don't wanna use sigmod but whatever
     {


### PR DESCRIPTION
Coordenates have been updated to use a valid position for them to spawn in due to the map updating to rc6